### PR TITLE
UmeResult numberOfGeneratedTests property

### DIFF
--- a/Ume Tests/UmeAPIIntegerTest.class.st
+++ b/Ume Tests/UmeAPIIntegerTest.class.st
@@ -79,5 +79,5 @@ UmeAPIIntegerTest >> testIntegerAdditionOnlyOutliers [
 	result := runner run.
 	
 	(result tests) do: [ :t | self assert: t feedback improvement > 0 ].
-	self assert: (result totalTest) equals: 5. 
+	self assert: (result numberOfGeneratedTests ) equals: 5. 
 ]

--- a/Ume Tests/UmeAPIIntegerTest.class.st
+++ b/Ume Tests/UmeAPIIntegerTest.class.st
@@ -78,6 +78,6 @@ UmeAPIIntegerTest >> testIntegerAdditionOnlyOutliers [
 	runner guidedByExecutionTime.
 	result := runner run.
 	
-	"self assertSuccess: result."
 	(result tests) do: [ :t | self assert: t feedback improvement > 0 ].
+	self assert: (result totalTest) equals: 5. 
 ]

--- a/Ume Tests/UmeAPINeoJsonTest.class.st
+++ b/Ume Tests/UmeAPINeoJsonTest.class.st
@@ -103,7 +103,7 @@ UmeAPINeoJsonTest >> testNeoJsonPerformanceOutliersOnly [
 
 	self assertSuccess: result.
 	(result tests) do: [ :t | self assert: t feedback improvement > 0 ].
-	self assert: (result totalTest) > 0. 
+	self assert: (result numberOfGeneratedTests ) > 0. 
 	
 
 ]

--- a/Ume Tests/UmeAPINeoJsonTest.class.st
+++ b/Ume Tests/UmeAPINeoJsonTest.class.st
@@ -103,6 +103,7 @@ UmeAPINeoJsonTest >> testNeoJsonPerformanceOutliersOnly [
 
 	self assertSuccess: result.
 	(result tests) do: [ :t | self assert: t feedback improvement > 0 ].
+	self assert: (result totalTest) > 0. 
 	
 
 ]

--- a/Ume Tests/UmeAPISortingTest.class.st
+++ b/Ume Tests/UmeAPISortingTest.class.st
@@ -90,5 +90,5 @@ UmeAPISortingTest >> testSortingCollectionOutliersOnly [
 
 	"self assertSuccess: result."
 	(result tests) do: [ :t | self assert: t feedback improvement > 0 ].
-	self assert: (result totalTest) equals: 5. 
+	self assert: (result numberOfGeneratedTests ) equals: 5. 
 ]

--- a/Ume Tests/UmeAPISortingTest.class.st
+++ b/Ume Tests/UmeAPISortingTest.class.st
@@ -90,4 +90,5 @@ UmeAPISortingTest >> testSortingCollectionOutliersOnly [
 
 	"self assertSuccess: result."
 	(result tests) do: [ :t | self assert: t feedback improvement > 0 ].
+	self assert: (result totalTest) equals: 5. 
 ]

--- a/Ume/UmeResult.class.st
+++ b/Ume/UmeResult.class.st
@@ -3,6 +3,7 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'tests',
+		'totalTest',
 		'totalTime',
 		'totalCoverage',
 		'performanceResult',
@@ -27,6 +28,27 @@ UmeResult class >> resultFrom: tests since: time withCoverage: totalCoverageResu
 	topCases := runner feedbackEvaluator topCases.
 
 	^ self new tests: tests;
+		totalTime: totalTime;
+		totalCoverage: totalCoverageResult;
+		topCases: topCases;
+		runner: runner;
+		feedbackEvaluator: runner feedbackEvaluator;
+		ranking: (tests collect: [ :test | test score ifNil: [ 0 ] ifNotNil: [ test score ] ]) asSortedCollection reverse;
+		performanceResult: perfResult
+]
+
+{ #category : 'as yet unclassified' }
+UmeResult class >> resultFrom: tests since: time withCoverage: totalCoverageResult runner: runner with: aNumberOfTest [
+
+	| totalTime totalTest perfResult topCases |
+	
+	totalTime := Duration milliSeconds: (Time millisecondsSince: time).
+	totalTest := aNumberOfTest.
+	perfResult := PerformanceResult from: tests withTime: totalTime.
+	topCases := runner feedbackEvaluator topCases.
+
+	^ self new tests: tests;
+		totalTest: totalTest;
 		totalTime: totalTime;
 		totalCoverage: totalCoverageResult;
 		topCases: topCases;
@@ -381,6 +403,19 @@ UmeResult >> totalCoverage [
 UmeResult >> totalCoverage: aTotalCoverage [
 
 	totalCoverage := aTotalCoverage
+
+]
+
+{ #category : 'getter' }
+UmeResult >> totalTest [ 
+
+	^ totalTest 
+]
+
+{ #category : 'setter' }
+UmeResult >> totalTest: aTotalTests [
+
+	totalTest  := aTotalTests 
 
 ]
 

--- a/Ume/UmeResult.class.st
+++ b/Ume/UmeResult.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'tests',
-		'totalTest',
+		'numberOfGeneratedTests',
 		'totalTime',
 		'totalCoverage',
 		'performanceResult',
@@ -40,22 +40,8 @@ UmeResult class >> resultFrom: tests since: time withCoverage: totalCoverageResu
 { #category : 'as yet unclassified' }
 UmeResult class >> resultFrom: tests since: time withCoverage: totalCoverageResult runner: runner with: aNumberOfTest [
 
-	| totalTime totalTest perfResult topCases |
 	
-	totalTime := Duration milliSeconds: (Time millisecondsSince: time).
-	totalTest := aNumberOfTest.
-	perfResult := PerformanceResult from: tests withTime: totalTime.
-	topCases := runner feedbackEvaluator topCases.
-
-	^ self new tests: tests;
-		totalTest: totalTest;
-		totalTime: totalTime;
-		totalCoverage: totalCoverageResult;
-		topCases: topCases;
-		runner: runner;
-		feedbackEvaluator: runner feedbackEvaluator;
-		ranking: (tests collect: [ :test | test score ifNil: [ 0 ] ifNotNil: [ test score ] ]) asSortedCollection reverse;
-		performanceResult: perfResult
+	^ (self resultFrom: tests since: time  withCoverage: totalCoverageResult  runner: runner) numberOfGeneratedTests: aNumberOfTest 
 ]
 
 { #category : 'as yet unclassified' }
@@ -164,6 +150,19 @@ UmeResult >> minimumTimeNeeded [
 UmeResult >> mutalkTest [
 
 	^ MTTestUmeCaseReference for: (UmeTestsuit from: tests)
+]
+
+{ #category : 'getter' }
+UmeResult >> numberOfGeneratedTests [ 
+
+	^ numberOfGeneratedTests 
+]
+
+{ #category : 'setter' }
+UmeResult >> numberOfGeneratedTests: aTotalTests [
+
+	numberOfGeneratedTests  := aTotalTests 
+
 ]
 
 { #category : 'outliers' }
@@ -403,19 +402,6 @@ UmeResult >> totalCoverage [
 UmeResult >> totalCoverage: aTotalCoverage [
 
 	totalCoverage := aTotalCoverage
-
-]
-
-{ #category : 'getter' }
-UmeResult >> totalTest [ 
-
-	^ totalTest 
-]
-
-{ #category : 'setter' }
-UmeResult >> totalTest: aTotalTests [
-
-	totalTest  := aTotalTests 
 
 ]
 

--- a/Ume/UmeRunner.class.st
+++ b/Ume/UmeRunner.class.st
@@ -249,6 +249,12 @@ UmeRunner >> genReport: tests since: time withCoverage: totalCoverageResult [
 ]
 
 { #category : 'tests' }
+UmeRunner >> genReport: tests since: time withCoverage: totalCoverageResult with: aNumberOfTest [
+
+	^ UmeResult resultFrom: tests since: time withCoverage: totalCoverageResult runner: self with: aNumberOfTest
+]
+
+{ #category : 'tests' }
 UmeRunner >> genTest: incrCoverage with: collector [
 
 	| arguments receiver result score caseFeedback test |
@@ -407,7 +413,7 @@ UmeRunner >> runCampaign: executionJob [
 		executionJob updateProgress: progress.
 		] ].
 
-	^ self genReport: tests since: time withCoverage: incrCoverage
+	^ self genReport: tests since: time withCoverage: incrCoverage with: iteration.
 ]
 
 { #category : 'accessing' }

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -2,7 +2,14 @@ Class {
 	#name : 'UmeShrinker',
 	#superclass : 'Object',
 	#instVars : [
-		'maxIterations'
+		'maxIterations',
+		'grammar',
+		'evaluator',
+		'feedbackEvaluator',
+		'threshold',
+		'programBlock',
+		'classesToProfile',
+		'memo'
 	],
 	#category : 'Ume-Shrinking',
 	#package : 'Ume',

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -2,13 +2,6 @@ Class {
 	#name : 'UmeShrinker',
 	#superclass : 'Object',
 	#instVars : [
-		'grammar',
-		'evaluator',
-		'feedbackEvaluator',
-		'threshold',
-		'programBlock',
-		'classesToProfile',
-		'memo',
 		'maxIterations'
 	],
 	#category : 'Ume-Shrinking',


### PR DESCRIPTION
Now, Ume Result can have a numberOfGeneratedTests property even if it only saves outliers, allowing us to know how many tests we generate.
 
``` smalltalk
runner := UmeRunner testWithLowCost: schema times: 5.
runner guidedByExecutionTime.
result := runner run.
	
(result tests) do: [ :t | self assert: t feedback improvement > 0 ].
self assert: (result numberOfGeneratedTests) equals: 5. "even though we have less than 5 outliers, we can know how many tests we did"
```