### PR TITLE
Ume progress-bar

### DIFF
--- a/Ume Tests/UmeAPISortingTest.class.st
+++ b/Ume Tests/UmeAPISortingTest.class.st
@@ -92,3 +92,23 @@ UmeAPISortingTest >> testSortingCollectionOutliersOnly [
 	(result tests) do: [ :t | self assert: t feedback improvement > 0 ].
 	self assert: (result numberOfGeneratedTests ) equals: 5. 
 ]
+
+{ #category : 'tests' }
+UmeAPISortingTest >> testSortingCollectionOutliersOnlyreRun [
+
+	| runner result result2 |
+	
+	runner := UmeRunner testWithLowCost: schema times: 5.
+	
+	runner guidedByExecutionTime.
+	result := runner run.
+
+	(result tests) do: [ :t | self assert: t feedback improvement > 0 ].
+	self assert: (result numberOfGeneratedTests ) equals: 5. 
+	
+	result2 := result continue: 5.
+	
+	(result2 tests) do: [ :t | self assert: t feedback improvement > 0 ].
+	self assert: (result2 numberOfGeneratedTests ) equals: 10. 
+	
+]

--- a/Ume/Job.extension.st
+++ b/Ume/Job.extension.st
@@ -7,3 +7,19 @@ Job >> updateProgress: aProgress [
 		progress: ( aProgress );
 		title: 'Running Ume Campaign... (', (aProgress * 100) rounded asString , '%)'.
 ]
+
+{ #category : '*Ume' }
+Job >> updateProgress: aProgress with: aNumberOfTest [
+	
+	self 
+		progress: ( aProgress );
+		title: 'Running Ume Campaign | ', aNumberOfTest asString , ' generated tests | (', (aProgress * 100) rounded asString , '%)'.
+]
+
+{ #category : '*Ume' }
+Job >> updateProgress: aProgress with: aNumberOfTest saved: aNumberOfSavedTest [
+	
+	self 
+		progress: ( aProgress );
+		title: 'Running Ume Campaign | ', aNumberOfTest asString , ' generated tests | ', aNumberOfSavedTest asString , ' saved tests | (', (aProgress * 100) rounded asString , '%)'.
+]

--- a/Ume/UmeResult.class.st
+++ b/Ume/UmeResult.class.st
@@ -116,6 +116,17 @@ UmeResult >> feed: someTests time: aTime [
 	ranking := (tests collect: [ :test | test score ifNil: [ 0 ] ifNotNil: [ test score ] ]) asSortedCollection reverse.
 ]
 
+{ #category : 'as yet unclassified' }
+UmeResult >> feed: someTests time: aTime tests: aNumberOfTests [
+
+	tests := tests, someTests.
+	totalTime := totalTime  + (Duration milliSeconds: (Time millisecondsSince: aTime)).
+	numberOfGeneratedTests := numberOfGeneratedTests + aNumberOfTests.
+	performanceResult := PerformanceResult from: tests withTime: totalTime.
+	topCases := runner feedbackEvaluator topCases.
+	ranking := (tests collect: [ :test | test score ifNil: [ 0 ] ifNotNil: [ test score ] ]) asSortedCollection reverse.
+]
+
 { #category : 'accessing' }
 UmeResult >> feedbackEvaluator [
 	

--- a/Ume/UmeResult.class.st
+++ b/Ume/UmeResult.class.st
@@ -57,13 +57,13 @@ UmeResult >> bloxplotByTime [
 { #category : 'as yet unclassified' }
 UmeResult >> continue: numberOfCases [
 
-	^ runner continue: numberOfCases from: self
+	^ runner continue: numberOfCases
 ]
 
 { #category : 'as yet unclassified' }
 UmeResult >> continueFor: time [
 
-	^ runner continueFor: time from: self
+	^ runner continueFor: time
 ]
 
 { #category : 'as yet unclassified' }

--- a/Ume/UmeRunner.class.st
+++ b/Ume/UmeRunner.class.st
@@ -394,7 +394,7 @@ UmeRunner >> reRunCampaign: executionJob from: aResult [
 		test:= self genTest: incrCoverage with: collector.
 		(self shouldCollect: test) ifTrue: [ tests add: test ].
 		progress := self progressFor: tests since: time for: iteration.
-		executionJob updateProgress: progress.
+		executionJob updateProgress: progress with:iteration saved: tests size .
 		] ].
 
 	^ aResult feed: tests time: time tests: iteration
@@ -430,8 +430,8 @@ UmeRunner >> runCampaign: executionJob [
 		iteration := iteration + 1.
 		test:= self genTest: incrCoverage with: collector.
 		(self shouldCollect: test) ifTrue: [ tests add: test ].
-		progress := self progressFor: tests since: time for: iteration.
-		executionJob updateProgress: progress.
+		progress := self progressFor: tests since: time for: iteration .
+		executionJob updateProgress: progress with: iteration saved: tests size.
 		] ].
 
 	^ self genReport: tests since: time withCoverage: incrCoverage with: iteration.

--- a/Ume/UmeRunner.class.st
+++ b/Ume/UmeRunner.class.st
@@ -10,7 +10,8 @@ Class {
 		'lastFeedback',
 		'methodsToInstrument',
 		'feedbackEvaluator',
-		'shouldSaveAll'
+		'shouldSaveAll',
+		'previousResult'
 	],
 	#category : 'Ume-Runner',
 	#package : 'Ume',
@@ -216,14 +217,21 @@ UmeRunner >> collectAllCases [
 	shouldSaveAll := true. 
 ]
 
-{ #category : 'as yet unclassified' }
-UmeRunner >> continue: times from: result [
+{ #category : 'tests' }
+UmeRunner >> continue: times [
 
 	self withCriteria: (UmeCountCriteria new times: times).
-	^ self reRun: result.
+	^ self run
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'tests' }
+UmeRunner >> continueFor: time [
+	
+	self withCriteria: (UmeTimeCriteria new timeout: time).
+	^ self run.
+]
+
+{ #category : 'tests' }
 UmeRunner >> continueFor: time from: result [
 	
 	self withCriteria: (UmeTimeCriteria new timeout: time).
@@ -365,39 +373,22 @@ UmeRunner >> isKernelMethod: method [
 	^ method package name = 'Kernel'
 ]
 
+{ #category : 'accessing' }
+UmeRunner >> previousResult [
+
+	^ previousResult 
+]
+
+{ #category : 'accessing' }
+UmeRunner >> previousResult: aResult [
+
+	previousResult := aResult
+]
+
 { #category : 'tests' }
 UmeRunner >> progressFor: tests since: time for: iteration [
 	
 	^ stopCriteria progressFor: tests since: time for: iteration
-]
-
-{ #category : 'tests' }
-UmeRunner >> reRun: result [
-
-	^ [ :job | self reRunCampaign: job from: result ] asJob run.
-]
-
-{ #category : 'tests' }
-UmeRunner >> reRunCampaign: executionJob from: aResult [
- 
-	| tests test iteration time collector incrCoverage progress |
-	
-	time := Time millisecondClockValue.
-	tests := OrderedCollection new.
-	iteration := 0. 
-	collector := aResult totalCoverage collector.
-	incrCoverage := aResult totalCoverage.
-
-	collector runOn: [ [
-		self shouldGenNext: iteration since: time withCoverage: incrCoverage] whileTrue: [
-		iteration := iteration + 1.
-		test:= self genTest: incrCoverage with: collector.
-		(self shouldCollect: test) ifTrue: [ tests add: test ].
-		progress := self progressFor: tests since: time for: iteration.
-		executionJob updateProgress: progress with:iteration saved: tests size .
-		] ].
-
-	^ aResult feed: tests time: time tests: iteration
 ]
 
 { #category : 'tests' }
@@ -417,13 +408,15 @@ UmeRunner >> run [
 { #category : 'tests' }
 UmeRunner >> runCampaign: executionJob [
  
-	| tests test iteration time collector incrCoverage progress|
+	| tests test iteration time collector incrCoverage progress |
 	
 	time := Time millisecondClockValue.
 	tests := OrderedCollection new.
 	iteration := 0. 
-	collector := C2CoverageCollector new methods: self reachableMethods.
-	incrCoverage := IncrementalCoverageResult for: { target } from: collector.
+	collector := previousResult ifNotNil: [ previousResult totalCoverage collector ] 
+	ifNil: [ C2CoverageCollector new methods: self reachableMethods].
+	incrCoverage := previousResult ifNotNil: [ previousResult totalCoverage ] 
+	ifNil: [ IncrementalCoverageResult for: { target } from: collector].
 
 	collector runOn: [ [
 		self shouldGenNext: iteration since: time withCoverage: incrCoverage] whileTrue: [
@@ -434,7 +427,9 @@ UmeRunner >> runCampaign: executionJob [
 		executionJob updateProgress: progress with: iteration saved: tests size.
 		] ].
 
-	^ self genReport: tests since: time withCoverage: incrCoverage with: iteration.
+	previousResult ifNotNil: [ ^ previousResult feed: tests time: time tests: iteration ]  
+	ifNil: [ previousResult := self genReport: tests since: time withCoverage: incrCoverage with: iteration ].
+	^ previousResult. 
 ]
 
 { #category : 'accessing' }

--- a/Ume/UmeRunner.class.st
+++ b/Ume/UmeRunner.class.st
@@ -374,20 +374,30 @@ UmeRunner >> progressFor: tests since: time for: iteration [
 { #category : 'tests' }
 UmeRunner >> reRun: result [
 
-	| tests time collector incrCoverage |
+	^ [ :job | self reRunCampaign: job from: result ] asJob run.
+]
+
+{ #category : 'tests' }
+UmeRunner >> reRunCampaign: executionJob from: aResult [
+ 
+	| tests test iteration time collector incrCoverage progress |
 	
 	time := Time millisecondClockValue.
 	tests := OrderedCollection new.
-	collector := result totalCoverage collector.
-	incrCoverage := result totalCoverage.
+	iteration := 0. 
+	collector := aResult totalCoverage collector.
+	incrCoverage := aResult totalCoverage.
 
 	collector runOn: [ [
-		self shouldGenNext: tests since: time withCoverage: incrCoverage] whileTrue: [
-			tests add: (self genTest: incrCoverage with: collector).
-		]
-	].
+		self shouldGenNext: iteration since: time withCoverage: incrCoverage] whileTrue: [
+		iteration := iteration + 1.
+		test:= self genTest: incrCoverage with: collector.
+		(self shouldCollect: test) ifTrue: [ tests add: test ].
+		progress := self progressFor: tests since: time for: iteration.
+		executionJob updateProgress: progress.
+		] ].
 
-	^ result feed: tests time: time
+	^ aResult feed: tests time: time tests: iteration
 ]
 
 { #category : 'tests' }

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -2,14 +2,7 @@ Class {
 	#name : 'UmeShrinker',
 	#superclass : 'Object',
 	#instVars : [
-		'maxIterations',
-		'grammar',
-		'evaluator',
-		'feedbackEvaluator',
-		'threshold',
-		'programBlock',
-		'classesToProfile',
-		'memo'
+		'maxIterations'
 	],
 	#category : 'Ume-Shrinking',
 	#package : 'Ume',


### PR DESCRIPTION
## Progress bar 2 
This pr add a progress bar in case of a rerun of the previous Ume campaign. 
 It also update the Ume result `numberOfGeneratedTests` by adding the newly generated ones thanks to the new method `feed: someTests time: aTime tests: aNumberOfTests`.

Also add description to the progress bar by telling how much tests have been generated and how much have been saved.

<img width="690" height="196" alt="runningbar" src="https://github.com/user-attachments/assets/1e7ab7de-dfd1-4656-b584-deb08601d9a6" />

I also simplified the call to rerun of the campaign, we now only use the methods `continueFor:` and `continue: `.
``` st
receiver := UmeObjectConstraint new generator: (UmeGenerator oneOf: (SmallInteger minVal to: SmallInteger maxVal)).
arguments := { UmeObjectConstraint new generator: (UmeGenerator oneOf: (SmallInteger minVal to: SmallInteger maxVal))}.
property := [ :a :args :result | result = (a + args first) ].

schema := UmeSchema new
	receiverConstraint: receiver;
   argumentConstraints: arguments;
   property: property;
	method: SmallInteger >> #+.
	
runner := UmeRunner testWithLowCost: schema times: 5000.
	
runner guidedByExecutionTime.
result := runner run.

result continueFor: 10 seconds.  "to continue tests generation for 10 seconds"

result continue: 100 "to generate 100 more tests"
```