### PR TITLE
[POC] Bug Localization

### DIFF
--- a/Coverage2/C2CoverageResult.class.st
+++ b/Coverage2/C2CoverageResult.class.st
@@ -13,7 +13,8 @@ Class {
 		'collector',
 		'methods',
 		'nodes',
-		'fixedPercentage'
+		'fixedPercentage',
+		'timesExecuted'
 	],
 	#category : 'Coverage2',
 	#package : 'Coverage2'
@@ -124,6 +125,18 @@ C2CoverageResult >> printOn: aStream [
 		print: ((100.0 * nodes size / collector nodes size) rounded) ;
 		nextPutAll: '%)'
 
+]
+
+{ #category : 'accessing' }
+C2CoverageResult >> timesExecuted [
+
+	^ timesExecuted
+]
+
+{ #category : 'accessing' }
+C2CoverageResult >> timesExecuted: times [
+
+	timesExecuted := times
 ]
 
 { #category : 'computation' }

--- a/Coverage2/C2IncrementalResult.class.st
+++ b/Coverage2/C2IncrementalResult.class.st
@@ -11,11 +11,16 @@ Class {
 { #category : 'as yet unclassified' }
 C2IncrementalResult >> collectResult: collector [
 
-	| nodes |
-	nodes := coveredNodes collect: [ :tuple | self resolveNode: tuple ].
+	| nodes timesExecuted|
+
+	timesExecuted := coveredNodes keys inject: Dictionary new into: [ :dic :tuple |
+		dic at: (self resolveNode: tuple) put: (coveredNodes at: tuple). dic
+	].
+	nodes := timesExecuted keys.
 
 	^ C2CoverageResult new
 		  collector: collector;
+		  timesExecuted: timesExecuted;
 		  nodes: nodes;
 		  methods:
 			  (nodes collect: [ :node | node methodNode compiledMethod ]) asSet
@@ -24,20 +29,24 @@ C2IncrementalResult >> collectResult: collector [
 { #category : 'as yet unclassified' }
 C2IncrementalResult >> coverNode: aNodePath inMethod: aMethodName [
 
-	coveredNodes add: { aMethodName. aNodePath }
+	| tuple |
+	
+	tuple := { aMethodName. aNodePath }.
+
+	coveredNodes at: tuple update: [ :n | n + 1 ] initial: [ 1 ].
 ]
 
 { #category : 'as yet unclassified' }
 C2IncrementalResult >> initialize [
 
 	super initialize.
-	coveredNodes := Set new
+	coveredNodes := IdentityDictionary new.
 ]
 
 { #category : 'as yet unclassified' }
 C2IncrementalResult >> resolveNode: tuple [
 
-	^(Object readFrom: tuple first) ast childAtPath: tuple second 
+	^ (Object readFrom: tuple first) ast childAtPath: tuple second 
 	
 
 ]
@@ -45,7 +54,8 @@ C2IncrementalResult >> resolveNode: tuple [
 { #category : 'as yet unclassified' }
 C2IncrementalResult >> tagExecuted: aNodePath inMethod: aMethodName [
 
-	coveredNodes add: {
-			aMethodName.
-			aNodePath }
+	| tuple |
+
+	tuple := { aMethodName. aNodePath }.
+	coveredNodes at: tuple update: [ :n | n + 1 ] initial: [ 1 ].
 ]

--- a/Coverage2/C2IncrementalResult.class.st
+++ b/Coverage2/C2IncrementalResult.class.st
@@ -40,7 +40,7 @@ C2IncrementalResult >> coverNode: aNodePath inMethod: aMethodName [
 C2IncrementalResult >> initialize [
 
 	super initialize.
-	coveredNodes := IdentityDictionary new.
+	coveredNodes := Dictionary new.
 ]
 
 { #category : 'as yet unclassified' }

--- a/Ume Tests/UmeAPINeoJsonTest.class.st
+++ b/Ume Tests/UmeAPINeoJsonTest.class.st
@@ -99,7 +99,6 @@ UmeAPINeoJsonTest >> testNeoJsonPerformanceOutliersOnly [
 	runner := UmeRunner test: schema.
 
 	result := runner run.
-	1 halt.
 	self assertSuccess: result.
 
 	(result tests select: [ :test | test isError not ]) do: [ :test |

--- a/Ume Tests/UmeAPINeoJsonTest.class.st
+++ b/Ume Tests/UmeAPINeoJsonTest.class.st
@@ -99,7 +99,7 @@ UmeAPINeoJsonTest >> testNeoJsonPerformanceOutliersOnly [
 	runner := UmeRunner test: schema.
 
 	result := runner run.
-
+	1 halt.
 	self assertSuccess: result.
 
 	(result tests select: [ :test | test isError not ]) do: [ :test |

--- a/Ume/UmeBugLocalization.class.st
+++ b/Ume/UmeBugLocalization.class.st
@@ -1,0 +1,82 @@
+Class {
+	#name : 'UmeBugLocalization',
+	#superclass : 'Object',
+	#instVars : [
+		'errors',
+		'failures',
+		'outliers'
+	],
+	#category : 'Ume-Localization',
+	#package : 'Ume',
+	#tag : 'Localization'
+}
+
+{ #category : 'accessing' }
+UmeBugLocalization >> errors [
+
+	^ errors 
+]
+
+{ #category : 'accessing' }
+UmeBugLocalization >> errors: someErrors [
+
+	errors := someErrors 
+]
+
+{ #category : 'accessing' }
+UmeBugLocalization >> failures [
+	
+	^ failures 
+]
+
+{ #category : 'accessing' }
+UmeBugLocalization >> failures: someFailures [
+
+	failures := someFailures 
+]
+
+{ #category : 'initialization' }
+UmeBugLocalization >> initialize [ 
+	
+	super initialize.
+	errors := {}.
+	failures := {}.
+	outliers := {}
+]
+
+{ #category : 'accessing' }
+UmeBugLocalization >> outliers [
+
+	^ outliers 
+]
+
+{ #category : 'accessing' }
+UmeBugLocalization >> outliers: someOutliers [
+
+	outliers := someOutliers 
+]
+
+{ #category : 'as yet unclassified' }
+UmeBugLocalization >> unique: reports [
+
+	^ reports groupedBy: #bugId
+
+]
+
+{ #category : 'as yet unclassified' }
+UmeBugLocalization >> uniqueErrors [
+
+	^ self unique: errors
+]
+
+{ #category : 'as yet unclassified' }
+UmeBugLocalization >> uniqueFailures [
+
+	^ self unique: failures 
+]
+
+{ #category : 'as yet unclassified' }
+UmeBugLocalization >> uniqueOutliers [
+
+	^ self unique: outliers
+]

--- a/Ume/UmeBugLocalizer.class.st
+++ b/Ume/UmeBugLocalizer.class.st
@@ -78,11 +78,10 @@ UmeBugLocalizer >> coveredNodesDeltaBetween: baseline and: test [
 { #category : 'localization' }
 UmeBugLocalizer >> localize: umeResult [
 
-	^ {
-		'Errors' -> (self localizeErrors: umeResult).
-		'Failures' -> (self localizeFailures: umeResult).
-		'Outliers' -> (self localizeOutliers: umeResult)
-	} asDictionary
+	^ UmeBugLocalization new
+		errors: (self localizeErrors: umeResult);
+		failures: (self localizeFailures: umeResult);
+		outliers: (self localizeOutliers: umeResult)
 ]
 
 { #category : 'localization' }
@@ -129,7 +128,7 @@ UmeBugLocalizer >> localizeOutliers: umeResult [
 		bug
 	].
 	
-	^ { bugBaseline }, outlierbugs
+	^ ({ bugBaseline }, outlierbugs) asOrderedCollection
 
 ]
 

--- a/Ume/UmeBugLocalizer.class.st
+++ b/Ume/UmeBugLocalizer.class.st
@@ -1,10 +1,6 @@
 Class {
 	#name : 'UmeBugLocalizer',
 	#superclass : 'Object',
-	#instVars : [
-		'result',
-		'bugs'
-	],
 	#category : 'Ume-Localization',
 	#package : 'Ume',
 	#tag : 'Localization'
@@ -14,12 +10,6 @@ Class {
 UmeBugLocalizer class >> localize: aUmeResult [
 
 	^ self new localize: aUmeResult
-]
-
-{ #category : 'accessing' }
-UmeBugLocalizer >> bugs [
-
-	^ bugs
 ]
 
 { #category : 'localization' }
@@ -97,84 +87,98 @@ UmeBugLocalizer >> computeProfilingDeltaForOutliers: outlierTests normal: normal
 ]
 
 { #category : 'localization' }
-UmeBugLocalizer >> localize: aUmeResult [
+UmeBugLocalizer >> localize: umeResult [
 
-	result := aUmeResult.
+	^ {
+		'Errors' -> (self localizeErrors: umeResult).
+		'Failures' -> (self localizeFailures: umeResult).
+		'OutlierCauses' -> (self localizePerformanceOutliers: umeResult)
+	} asDictionary
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizeErrors: umeResult [
+
+	^ umeResult tests inject: OrderedCollection new into: [ :bugs :test |
+		test result isError ifTrue: [ bugs add: (UmeBugReport errorReport: test) ].
+		bugs
+	]
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizeFailures: umeResult [
+
+	| failingTests passingTests suspiciousness |
+
+	failingTests := umeResult tests select: [ :t | t result isFail ].
+	failingTests ifEmpty: [ ^ failingTests ].
+
+	passingTests := umeResult tests select: [ :t | t result isSuccess ].
+	passingTests ifEmpty: [ ^ passingTests ].
+
+	suspiciousness := self computeOchiaiForPassing: passingTests failing: failingTests.
+
+	^ failingTests collect: [ :test | UmeBugReport failReport: test from: suspiciousness ]
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizeOutliers: umeResult [
+
+	| outlierTests normalTests deltas bugs |
+	
 	bugs := OrderedCollection new.
+	1 halt.
+	outlierTests := umeResult outliersByCoverage.
+	outlierTests ifEmpty: [ ^ bugs ].
 
-	self localizeErrors.
-	self localizeFailures.
-	self localizePerformanceOutliers.
+	normalTests := umeResult tests select: [ :t |
+		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
+	normalTests ifEmpty: [ ^ bugs ].
 
+	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
+		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
+			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
+
+	deltas ifEmpty: [ ^ bugs ].
+
+	outlierTests do: [ :test |
+		| bug orderedSuspects |
+		bug := UmeBugReport for: test type: #performanceOutlier.
+		bug metric: #coverage.
+		bug suspiciousnessScores: deltas.
+
+		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
+			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
+		bug suspectedMethods: orderedSuspects.
+
+		test result coverageResult ifNotNil: [ :cov |
+			bug executedMethods: cov methods ].
+
+		bugs add: bug ].
+	
 	^ bugs
 ]
 
 { #category : 'localization' }
-UmeBugLocalizer >> localizeErrors [
+UmeBugLocalizer >> localizePerformanceOutliers: umeResult [
 
-	result tests do: [ :test |
-		(test result isKindOf: UmeEvalError) ifTrue: [ | bug topFrames |
-			bug := UmeBugReport for: test type: #error.
-			bug errorMessage: test result message.
-
-			test result stack ifNotNil: [ :frames |
-				bug stackTrace: frames.
-				topFrames := frames first: ((frames size) min: 3).
-				bug suspectedMethods: (topFrames collect: [ :frame | frame asString ]) asOrderedCollection ].
-
-			test result coverageResult ifNotNil: [ :cov |
-				bug executedMethods: cov methods.
-				bug uncoveredMethods: cov uncoveredMethods ].
-
-			bugs add: bug ] ]
+	^ self localizeOutliers: umeResult
+"	self localizePerformanceOutliersByExecutionTime: umeResult.
+	self localizePerformanceOutliersByMemory: umeResult.
+	self localizePerformanceOutliersByCoverage: umeResult.
+	self localizePerformanceOutliersByScore: umeResult"
 ]
 
 { #category : 'localization' }
-UmeBugLocalizer >> localizeFailures [
+UmeBugLocalizer >> localizePerformanceOutliersByCoverage: umeResult [
 
-	| failingTests passingTests suspiciousness |
-	failingTests := result tests select: [ :t | t result isKindOf: UmeEvalFail ].
-	failingTests ifEmpty: [ ^ self ].
-
-	passingTests := result tests select: [ :t | t result isKindOf: UmeEvalSuccess ].
-	passingTests ifEmpty: [ ^ self ].
-
-	suspiciousness := self computeOchiaiForPassing: passingTests failing: failingTests.
-	suspiciousness ifEmpty: [ ^ self ].
-
-	failingTests do: [ :test |
-		| bug orderedSuspects |
-		bug := UmeBugReport for: test type: #propertyFail.
-		bug suspiciousnessScores: suspiciousness.
-
-		orderedSuspects := (suspiciousness keys asSortedCollection: [ :a :b |
-			(suspiciousness at: a) > (suspiciousness at: b) ]) asOrderedCollection.
-		bug suspectedMethods: orderedSuspects.
-
-		test result coverageResult ifNotNil: [ :cov |
-			bug executedMethods: cov methods.
-			bug uncoveredMethods: cov uncoveredMethods ].
-
-		bugs add: bug ]
-]
-
-{ #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliers [
-
-	self localizePerformanceOutliersByExecutionTime.
-	self localizePerformanceOutliersByMemory.
-	self localizePerformanceOutliersByCoverage.
-	self localizePerformanceOutliersByScore
-]
-
-{ #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliersByCoverage [
-
-	| outlierTests normalTests deltas |
-	outlierTests := result outliersByCoverage.
+	| outlierTests normalTests deltas bugs |
+	
+	bugs := OrderedCollection new.
+	outlierTests := umeResult outliersByCoverage.
 	outlierTests ifEmpty: [ ^ self ].
 
-	normalTests := result tests select: [ :t |
+	normalTests := umeResult tests select: [ :t |
 		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
 	normalTests ifEmpty: [ ^ self ].
 
@@ -197,17 +201,21 @@ UmeBugLocalizer >> localizePerformanceOutliersByCoverage [
 		test result coverageResult ifNotNil: [ :cov |
 			bug executedMethods: cov methods ].
 
-		bugs add: bug ]
+		bugs add: bug ].
+	
+	^ bugs
 ]
 
 { #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliersByExecutionTime [
+UmeBugLocalizer >> localizePerformanceOutliersByExecutionTime: umeResult [
 
-	| outlierTests normalTests deltas |
-	outlierTests := result outliersByExecutionTime.
+	| outlierTests normalTests deltas bugs |
+	
+	bugs := OrderedCollection new.
+	outlierTests := umeResult outliersByExecutionTime.
 	outlierTests ifEmpty: [ ^ self ].
 
-	normalTests := result tests select: [ :t |
+	normalTests := umeResult tests select: [ :t |
 		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
 	normalTests ifEmpty: [ ^ self ].
 
@@ -230,17 +238,21 @@ UmeBugLocalizer >> localizePerformanceOutliersByExecutionTime [
 		test result coverageResult ifNotNil: [ :cov |
 			bug executedMethods: cov methods ].
 
-		bugs add: bug ]
+		bugs add: bug ].
+	
+	^ bugs
 ]
 
 { #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliersByMemory [
+UmeBugLocalizer >> localizePerformanceOutliersByMemory: umeResult [
 
-	| outlierTests normalTests deltas |
-	outlierTests := result outliersByAllocatedMemory.
+	| outlierTests normalTests deltas bugs |
+	
+	bugs := OrderedCollection new.
+	outlierTests := umeResult outliersByAllocatedMemory.
 	outlierTests ifEmpty: [ ^ self ].
 
-	normalTests := result tests select: [ :t |
+	normalTests := umeResult tests select: [ :t |
 		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
 	normalTests ifEmpty: [ ^ self ].
 
@@ -263,17 +275,21 @@ UmeBugLocalizer >> localizePerformanceOutliersByMemory [
 		test result coverageResult ifNotNil: [ :cov |
 			report executedMethods: cov methods ].
 
-		bugs add: report ]
+		bugs add: report ].
+	
+	^ bugs
 ]
 
 { #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliersByScore [
+UmeBugLocalizer >> localizePerformanceOutliersByScore: umeResult [
 
-	| outlierTests normalTests deltas |
-	outlierTests := result outliersByScore.
+	| outlierTests normalTests deltas bugs |
+	
+	bugs := OrderedCollection new.
+	outlierTests := umeResult outliersByScore.
 	outlierTests ifEmpty: [ ^ self ].
 
-	normalTests := result tests select: [ :t |
+	normalTests := umeResult tests select: [ :t |
 		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
 	normalTests ifEmpty: [ ^ self ].
 
@@ -296,17 +312,7 @@ UmeBugLocalizer >> localizePerformanceOutliersByScore [
 		test result coverageResult ifNotNil: [ :cov |
 			bug executedMethods: cov methods ].
 
-		bugs add: bug ]
-]
-
-{ #category : 'accessing' }
-UmeBugLocalizer >> result [
-
-	^ result
-]
-
-{ #category : 'accessing' }
-UmeBugLocalizer >> result: aUmeResult [
-
-	result := aUmeResult
+		bugs add: bug ].
+	
+	^ bugs
 ]

--- a/Ume/UmeBugLocalizer.class.st
+++ b/Ume/UmeBugLocalizer.class.st
@@ -34,8 +34,7 @@ UmeBugLocalizer >> computeOchiaiForPassing: passingTests failing: failingTests [
 			methodFailedCount at: method put: (methodFailedCount at: method ifAbsent: [ 0 ]) + 1 ] ].
 
 	suspiciousness := Dictionary new.
-	allMethods do: [ :method |
-		| failed passed divisor score |
+	allMethods do: [ :method | | failed passed divisor score |
 		failed := methodFailedCount at: method ifAbsent: [ 0 ].
 		passed := methodPassedCount at: method ifAbsent: [ 0 ].
 		divisor := totalFailed * (failed + passed) asFloat.
@@ -48,42 +47,25 @@ UmeBugLocalizer >> computeOchiaiForPassing: passingTests failing: failingTests [
 ]
 
 { #category : 'localization' }
-UmeBugLocalizer >> computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: valueBlock [
+UmeBugLocalizer >> coveredMethodDeltaBetween: baseline and: test [
 
-	| outlierValues normalValues allKeys deltas |
-	outlierValues := Dictionary new.
-	normalValues := Dictionary new.
-	allKeys := Set new.
+	| baselineMethods testMethods |
+	
+	baselineMethods := baseline result coverageResult methods.
+	testMethods := test result coverageResult methods.
 
-	outlierTests do: [ :test | | values |
-		values := valueBlock value: test.
-		values keysAndValuesDo: [ :key :val |
-			allKeys add: key.
-			outlierValues at: key put: (outlierValues at: key ifAbsent: [ 0 ]) + val ] ].
+	^ testMethods difference: baselineMethods
+]
 
-	outlierTests ifNotEmpty: [
-		outlierValues keysAndValuesDo: [ :key :sum |
-			outlierValues at: key put: sum / outlierTests size ] ].
+{ #category : 'localization' }
+UmeBugLocalizer >> coveredNodesDeltaBetween: baseline and: test [
+	
+	| baselineNodes testNodes |
+	
+	baselineNodes := baseline result coverageResult nodes.
+	testNodes := test result coverageResult nodes.
 
-	normalTests do: [ :test | | values |
-		values := valueBlock value: test.
-		values keysAndValuesDo: [ :key :val |
-			allKeys add: key.
-			normalValues at: key put: (normalValues at: key ifAbsent: [ 0 ]) + val ] ].
-
-	normalTests ifNotEmpty: [
-		normalValues keysAndValuesDo: [ :key :sum |
-			normalValues at: key put: sum / normalTests size ] ].
-
-	deltas := Dictionary new.
-	allKeys do: [ :key |
-		| outlierAvg normalAvg delta |
-		outlierAvg := outlierValues at: key ifAbsent: [ 0.0 ].
-		normalAvg := normalValues at: key ifAbsent: [ 0.0 ].
-		delta := outlierAvg - normalAvg.
-		delta > 0 ifTrue: [ deltas at: key put: delta ] ].
-
-	^ deltas
+	^ testNodes difference: baselineNodes
 ]
 
 { #category : 'localization' }
@@ -92,7 +74,7 @@ UmeBugLocalizer >> localize: umeResult [
 	^ {
 		'Errors' -> (self localizeErrors: umeResult).
 		'Failures' -> (self localizeFailures: umeResult).
-		'OutlierCauses' -> (self localizePerformanceOutliers: umeResult)
+		'OutlierCauses' -> (self localizeOutliers: umeResult)
 	} asDictionary
 ]
 
@@ -124,195 +106,36 @@ UmeBugLocalizer >> localizeFailures: umeResult [
 { #category : 'localization' }
 UmeBugLocalizer >> localizeOutliers: umeResult [
 
-	| outlierTests normalTests deltas bugs |
+	| outliers baseline |
+
+	umeResult topCases ifEmpty: [ ^ OrderedCollection new ].
+	outliers := umeResult topCases allButFirst select: [ :test | test result isSuccess ].
+	baseline := umeResult topCases first.
 	
-	bugs := OrderedCollection new.
-	1 halt.
-	outlierTests := umeResult outliersByCoverage.
-	outlierTests ifEmpty: [ ^ bugs ].
-
-	normalTests := umeResult tests select: [ :t |
-		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
-	normalTests ifEmpty: [ ^ bugs ].
-
-	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
-		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
-			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
-
-	deltas ifEmpty: [ ^ bugs ].
-
-	outlierTests do: [ :test |
-		| bug orderedSuspects |
-		bug := UmeBugReport for: test type: #performanceOutlier.
-		bug metric: #coverage.
-		bug suspiciousnessScores: deltas.
-
-		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
-			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
-		bug suspectedMethods: orderedSuspects.
-
-		test result coverageResult ifNotNil: [ :cov |
-			bug executedMethods: cov methods ].
-
-		bugs add: bug ].
-	
-	^ bugs
+	^ outliers collect: [ :test | | bug delta deltaMethods deltaNodes |
+		delta := self profilingDeltaBetween: baseline and: test.
+		deltaMethods := self coveredMethodDeltaBetween: baseline and: test.
+		deltaNodes :=  self coveredNodesDeltaBetween: baseline and: test.
+		bug := UmeBugReport outlierReport: test delta: delta suspectedMethods: deltaMethods suspectedNodes: deltaNodes.
+		baseline := test.
+		bug
+	]
 ]
 
 { #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliers: umeResult [
+UmeBugLocalizer >> profilingDeltaBetween: baseline and: test [
 
-	^ self localizeOutliers: umeResult
-"	self localizePerformanceOutliersByExecutionTime: umeResult.
-	self localizePerformanceOutliersByMemory: umeResult.
-	self localizePerformanceOutliersByCoverage: umeResult.
-	self localizePerformanceOutliersByScore: umeResult"
-]
-
-{ #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliersByCoverage: umeResult [
-
-	| outlierTests normalTests deltas bugs |
+	| baselineValues testValues |
 	
-	bugs := OrderedCollection new.
-	outlierTests := umeResult outliersByCoverage.
-	outlierTests ifEmpty: [ ^ self ].
+	baselineValues := baseline feedback values.
+	testValues := test feedback values.
 
-	normalTests := umeResult tests select: [ :t |
-		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
-	normalTests ifEmpty: [ ^ self ].
-
-	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
-		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
-			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
-
-	deltas ifEmpty: [ ^ self ].
-
-	outlierTests do: [ :test |
-		| bug orderedSuspects |
-		bug := UmeBugReport for: test type: #performanceOutlier.
-		bug metric: #coverage.
-		bug suspiciousnessScores: deltas.
-
-		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
-			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
-		bug suspectedMethods: orderedSuspects.
-
-		test result coverageResult ifNotNil: [ :cov |
-			bug executedMethods: cov methods ].
-
-		bugs add: bug ].
-	
-	^ bugs
-]
-
-{ #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliersByExecutionTime: umeResult [
-
-	| outlierTests normalTests deltas bugs |
-	
-	bugs := OrderedCollection new.
-	outlierTests := umeResult outliersByExecutionTime.
-	outlierTests ifEmpty: [ ^ self ].
-
-	normalTests := umeResult tests select: [ :t |
-		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
-	normalTests ifEmpty: [ ^ self ].
-
-	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
-		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
-			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
-
-	deltas ifEmpty: [ ^ self ].
-
-	outlierTests do: [ :test |
-		| bug orderedSuspects |
-		bug := UmeBugReport for: test type: #performanceOutlier.
-		bug metric: #executionTime.
-		bug suspiciousnessScores: deltas.
-
-		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
-			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
-		bug suspectedMethods: orderedSuspects.
-
-		test result coverageResult ifNotNil: [ :cov |
-			bug executedMethods: cov methods ].
-
-		bugs add: bug ].
-	
-	^ bugs
-]
-
-{ #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliersByMemory: umeResult [
-
-	| outlierTests normalTests deltas bugs |
-	
-	bugs := OrderedCollection new.
-	outlierTests := umeResult outliersByAllocatedMemory.
-	outlierTests ifEmpty: [ ^ self ].
-
-	normalTests := umeResult tests select: [ :t |
-		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
-	normalTests ifEmpty: [ ^ self ].
-
-	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
-		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
-			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
-
-	deltas ifEmpty: [ ^ self ].
-
-	outlierTests do: [ :test |
-		| report orderedSuspects |
-		report := UmeBugReport for: test type: #performanceOutlier.
-		report metric: #allocatedMemory.
-		report suspiciousnessScores: deltas.
-
-		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
-			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
-		report suspectedMethods: orderedSuspects.
-
-		test result coverageResult ifNotNil: [ :cov |
-			report executedMethods: cov methods ].
-
-		bugs add: report ].
-	
-	^ bugs
-]
-
-{ #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliersByScore: umeResult [
-
-	| outlierTests normalTests deltas bugs |
-	
-	bugs := OrderedCollection new.
-	outlierTests := umeResult outliersByScore.
-	outlierTests ifEmpty: [ ^ self ].
-
-	normalTests := umeResult tests select: [ :t |
-		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
-	normalTests ifEmpty: [ ^ self ].
-
-	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
-		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
-			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
-
-	deltas ifEmpty: [ ^ self ].
-
-	outlierTests do: [ :test |
-		| bug orderedSuspects |
-		bug := UmeBugReport for: test type: #performanceOutlier.
-		bug metric: #score.
-		bug suspiciousnessScores: deltas.
-
-		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
-			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
-		bug suspectedMethods: orderedSuspects.
-
-		test result coverageResult ifNotNil: [ :cov |
-			bug executedMethods: cov methods ].
-
-		bugs add: bug ].
-	
-	^ bugs
+	^ testValues keys inject: Dictionary new into: [ :diff :key | | currentValue baselineValue |
+		currentValue := testValues at: key.
+		baselineValue := baselineValues at: key ifAbsent: [ 0 ].
+		(currentValue > baselineValue) ifTrue: [
+			diff at: key put: (currentValue - baselineValue)
+		].
+		diff
+	]
 ]

--- a/Ume/UmeBugLocalizer.class.st
+++ b/Ume/UmeBugLocalizer.class.st
@@ -81,7 +81,7 @@ UmeBugLocalizer >> localize: umeResult [
 	^ {
 		'Errors' -> (self localizeErrors: umeResult).
 		'Failures' -> (self localizeFailures: umeResult).
-		'OutlierCauses' -> (self localizeOutliers: umeResult)
+		'Outliers' -> (self localizeOutliers: umeResult)
 	} asDictionary
 ]
 
@@ -113,20 +113,24 @@ UmeBugLocalizer >> localizeFailures: umeResult [
 { #category : 'localization' }
 UmeBugLocalizer >> localizeOutliers: umeResult [
 
-	| outliers baseline |
+	| outliers baseline bugBaseline outlierbugs |
 
 	umeResult topCases ifEmpty: [ ^ OrderedCollection new ].
 	outliers := umeResult topCases allButFirst select: [ :test | test result isSuccess ].
 	baseline := umeResult topCases first.
+	bugBaseline := UmeBugReport outlierBaseline: baseline.
 	
-	^ outliers collect: [ :test | | bug delta deltaMethods deltaNodes |
+	outlierbugs := outliers collect: [ :test | | bug delta deltaMethods deltaNodes |
 		delta := self profilingDeltaBetween: baseline and: test.
 		deltaMethods := self coveredMethodDeltaBetween: baseline and: test.
 		deltaNodes := self coveredNodesDeltaBetween: baseline and: test.
 		bug := UmeBugReport outlierReport: test delta: delta suspectedMethods: deltaMethods suspectedNodes: deltaNodes.
 		baseline := test.
 		bug
-	]
+	].
+	
+	^ { bugBaseline }, outlierbugs
+
 ]
 
 { #category : 'localization' }

--- a/Ume/UmeBugLocalizer.class.st
+++ b/Ume/UmeBugLocalizer.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'result',
-		'reports'
+		'bugs'
 	],
 	#category : 'Ume-Localization',
 	#package : 'Ume',
@@ -11,9 +11,15 @@ Class {
 }
 
 { #category : 'instance creation' }
-UmeBugLocalizer class >> on: aUmeResult [
+UmeBugLocalizer class >> localize: aUmeResult [
 
-	^ self new result: aUmeResult
+	^ self new localize: aUmeResult
+]
+
+{ #category : 'accessing' }
+UmeBugLocalizer >> bugs [
+
+	^ bugs
 ]
 
 { #category : 'localization' }
@@ -94,33 +100,33 @@ UmeBugLocalizer >> computeProfilingDeltaForOutliers: outlierTests normal: normal
 UmeBugLocalizer >> localize: aUmeResult [
 
 	result := aUmeResult.
-	reports := OrderedCollection new.
+	bugs := OrderedCollection new.
 
 	self localizeErrors.
 	self localizeFailures.
 	self localizePerformanceOutliers.
 
-	^ reports
+	^ bugs
 ]
 
 { #category : 'localization' }
 UmeBugLocalizer >> localizeErrors [
 
 	result tests do: [ :test |
-		(test result isKindOf: UmeEvalError) ifTrue: [ | report topFrames |
-			report := UmeBugReport for: test type: #error.
-			report errorMessage: test result message.
+		(test result isKindOf: UmeEvalError) ifTrue: [ | bug topFrames |
+			bug := UmeBugReport for: test type: #error.
+			bug errorMessage: test result message.
 
 			test result stack ifNotNil: [ :frames |
-				report stackTrace: frames.
+				bug stackTrace: frames.
 				topFrames := frames first: ((frames size) min: 3).
-				report suspectedMethods: (topFrames collect: [ :frame | frame asString ]) asOrderedCollection ].
+				bug suspectedMethods: (topFrames collect: [ :frame | frame asString ]) asOrderedCollection ].
 
 			test result coverageResult ifNotNil: [ :cov |
-				report executedMethods: cov methods.
-				report uncoveredMethods: cov uncoveredMethods ].
+				bug executedMethods: cov methods.
+				bug uncoveredMethods: cov uncoveredMethods ].
 
-			reports add: report ] ]
+			bugs add: bug ] ]
 ]
 
 { #category : 'localization' }
@@ -137,19 +143,19 @@ UmeBugLocalizer >> localizeFailures [
 	suspiciousness ifEmpty: [ ^ self ].
 
 	failingTests do: [ :test |
-		| report orderedSuspects |
-		report := UmeBugReport for: test type: #propertyFail.
-		report suspiciousnessScores: suspiciousness.
+		| bug orderedSuspects |
+		bug := UmeBugReport for: test type: #propertyFail.
+		bug suspiciousnessScores: suspiciousness.
 
 		orderedSuspects := (suspiciousness keys asSortedCollection: [ :a :b |
 			(suspiciousness at: a) > (suspiciousness at: b) ]) asOrderedCollection.
-		report suspectedMethods: orderedSuspects.
+		bug suspectedMethods: orderedSuspects.
 
 		test result coverageResult ifNotNil: [ :cov |
-			report executedMethods: cov methods.
-			report uncoveredMethods: cov uncoveredMethods ].
+			bug executedMethods: cov methods.
+			bug uncoveredMethods: cov uncoveredMethods ].
 
-		reports add: report ]
+		bugs add: bug ]
 ]
 
 { #category : 'localization' }
@@ -159,6 +165,39 @@ UmeBugLocalizer >> localizePerformanceOutliers [
 	self localizePerformanceOutliersByMemory.
 	self localizePerformanceOutliersByCoverage.
 	self localizePerformanceOutliersByScore
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizePerformanceOutliersByCoverage [
+
+	| outlierTests normalTests deltas |
+	outlierTests := result outliersByCoverage.
+	outlierTests ifEmpty: [ ^ self ].
+
+	normalTests := result tests select: [ :t |
+		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
+	normalTests ifEmpty: [ ^ self ].
+
+	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
+		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
+			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
+
+	deltas ifEmpty: [ ^ self ].
+
+	outlierTests do: [ :test |
+		| bug orderedSuspects |
+		bug := UmeBugReport for: test type: #performanceOutlier.
+		bug metric: #coverage.
+		bug suspiciousnessScores: deltas.
+
+		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
+			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
+		bug suspectedMethods: orderedSuspects.
+
+		test result coverageResult ifNotNil: [ :cov |
+			bug executedMethods: cov methods ].
+
+		bugs add: bug ]
 ]
 
 { #category : 'localization' }
@@ -179,19 +218,19 @@ UmeBugLocalizer >> localizePerformanceOutliersByExecutionTime [
 	deltas ifEmpty: [ ^ self ].
 
 	outlierTests do: [ :test |
-		| report orderedSuspects |
-		report := UmeBugReport for: test type: #performanceOutlier.
-		report metric: #executionTime.
-		report suspiciousnessScores: deltas.
+		| bug orderedSuspects |
+		bug := UmeBugReport for: test type: #performanceOutlier.
+		bug metric: #executionTime.
+		bug suspiciousnessScores: deltas.
 
 		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
 			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
-		report suspectedMethods: orderedSuspects.
+		bug suspectedMethods: orderedSuspects.
 
 		test result coverageResult ifNotNil: [ :cov |
-			report executedMethods: cov methods ].
+			bug executedMethods: cov methods ].
 
-		reports add: report ]
+		bugs add: bug ]
 ]
 
 { #category : 'localization' }
@@ -224,40 +263,7 @@ UmeBugLocalizer >> localizePerformanceOutliersByMemory [
 		test result coverageResult ifNotNil: [ :cov |
 			report executedMethods: cov methods ].
 
-		reports add: report ]
-]
-
-{ #category : 'localization' }
-UmeBugLocalizer >> localizePerformanceOutliersByCoverage [
-
-	| outlierTests normalTests deltas |
-	outlierTests := result outliersByCoverage.
-	outlierTests ifEmpty: [ ^ self ].
-
-	normalTests := result tests select: [ :t |
-		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
-	normalTests ifEmpty: [ ^ self ].
-
-	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
-		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
-			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
-
-	deltas ifEmpty: [ ^ self ].
-
-	outlierTests do: [ :test |
-		| report orderedSuspects |
-		report := UmeBugReport for: test type: #performanceOutlier.
-		report metric: #coverage.
-		report suspiciousnessScores: deltas.
-
-		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
-			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
-		report suspectedMethods: orderedSuspects.
-
-		test result coverageResult ifNotNil: [ :cov |
-			report executedMethods: cov methods ].
-
-		reports add: report ]
+		bugs add: report ]
 ]
 
 { #category : 'localization' }
@@ -278,25 +284,19 @@ UmeBugLocalizer >> localizePerformanceOutliersByScore [
 	deltas ifEmpty: [ ^ self ].
 
 	outlierTests do: [ :test |
-		| report orderedSuspects |
-		report := UmeBugReport for: test type: #performanceOutlier.
-		report metric: #score.
-		report suspiciousnessScores: deltas.
+		| bug orderedSuspects |
+		bug := UmeBugReport for: test type: #performanceOutlier.
+		bug metric: #score.
+		bug suspiciousnessScores: deltas.
 
 		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
 			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
-		report suspectedMethods: orderedSuspects.
+		bug suspectedMethods: orderedSuspects.
 
 		test result coverageResult ifNotNil: [ :cov |
-			report executedMethods: cov methods ].
+			bug executedMethods: cov methods ].
 
-		reports add: report ]
-]
-
-{ #category : 'accessing' }
-UmeBugLocalizer >> reports [
-
-	^ reports
+		bugs add: bug ]
 ]
 
 { #category : 'accessing' }

--- a/Ume/UmeBugLocalizer.class.st
+++ b/Ume/UmeBugLocalizer.class.st
@@ -67,7 +67,7 @@ UmeBugLocalizer >> coveredNodesDeltaBetween: baseline and: test [
 
 	^ testNodes keys inject: Dictionary new into: [ :dic :key | | currentValue baselineValue |
 		currentValue := testNodes at: key.
-		baselineValue := baselineNodes at: key.
+		baselineValue := baselineNodes at: key ifAbsent: [ 0 ].
 		(currentValue > baselineValue) ifTrue: [
 			dic at: key put: (currentValue - baselineValue)
 		].

--- a/Ume/UmeBugLocalizer.class.st
+++ b/Ume/UmeBugLocalizer.class.st
@@ -61,11 +61,18 @@ UmeBugLocalizer >> coveredMethodDeltaBetween: baseline and: test [
 UmeBugLocalizer >> coveredNodesDeltaBetween: baseline and: test [
 	
 	| baselineNodes testNodes |
-	
-	baselineNodes := baseline result coverageResult nodes.
-	testNodes := test result coverageResult nodes.
 
-	^ testNodes difference: baselineNodes
+	baselineNodes := baseline result coverageResult timesExecuted.
+	testNodes := test result coverageResult timesExecuted.
+
+	^ testNodes keys inject: Dictionary new into: [ :dic :key | | currentValue baselineValue |
+		currentValue := testNodes at: key.
+		baselineValue := baselineNodes at: key.
+		(currentValue > baselineValue) ifTrue: [
+			dic at: key put: (currentValue - baselineValue)
+		].
+		dic	
+	]
 ]
 
 { #category : 'localization' }
@@ -115,7 +122,7 @@ UmeBugLocalizer >> localizeOutliers: umeResult [
 	^ outliers collect: [ :test | | bug delta deltaMethods deltaNodes |
 		delta := self profilingDeltaBetween: baseline and: test.
 		deltaMethods := self coveredMethodDeltaBetween: baseline and: test.
-		deltaNodes :=  self coveredNodesDeltaBetween: baseline and: test.
+		deltaNodes := self coveredNodesDeltaBetween: baseline and: test.
 		bug := UmeBugReport outlierReport: test delta: delta suspectedMethods: deltaMethods suspectedNodes: deltaNodes.
 		baseline := test.
 		bug

--- a/Ume/UmeBugLocalizer.class.st
+++ b/Ume/UmeBugLocalizer.class.st
@@ -1,0 +1,312 @@
+Class {
+	#name : 'UmeBugLocalizer',
+	#superclass : 'Object',
+	#instVars : [
+		'result',
+		'reports'
+	],
+	#category : 'Ume-Localization',
+	#package : 'Ume',
+	#tag : 'Localization'
+}
+
+{ #category : 'instance creation' }
+UmeBugLocalizer class >> on: aUmeResult [
+
+	^ self new result: aUmeResult
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> computeOchiaiForPassing: passingTests failing: failingTests [
+
+	| totalFailed suspiciousness allMethods methodFailedCount methodPassedCount |
+	totalFailed := failingTests size.
+	totalFailed = 0 ifTrue: [ ^ Dictionary new ].
+
+	allMethods := Set new.
+	methodFailedCount := Dictionary new.
+	methodPassedCount := Dictionary new.
+
+	passingTests do: [ :test |
+		(test result coverageResult ifNil: [ #() ] ifNotNil: [ test result coverageResult methods ]) do: [ :method |
+			allMethods add: method.
+			methodPassedCount at: method put: (methodPassedCount at: method ifAbsent: [ 0 ]) + 1 ] ].
+
+	failingTests do: [ :test |
+		(test result coverageResult ifNil: [ #() ] ifNotNil: [ test result coverageResult methods ]) do: [ :method |
+			allMethods add: method.
+			methodFailedCount at: method put: (methodFailedCount at: method ifAbsent: [ 0 ]) + 1 ] ].
+
+	suspiciousness := Dictionary new.
+	allMethods do: [ :method |
+		| failed passed divisor score |
+		failed := methodFailedCount at: method ifAbsent: [ 0 ].
+		passed := methodPassedCount at: method ifAbsent: [ 0 ].
+		divisor := totalFailed * (failed + passed) asFloat.
+		score := divisor > 0
+			ifTrue: [ failed / divisor sqrt ]
+			ifFalse: [ 0.0 ].
+		score > 0 ifTrue: [ suspiciousness at: method put: score ] ].
+
+	^ suspiciousness
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: valueBlock [
+
+	| outlierValues normalValues allKeys deltas |
+	outlierValues := Dictionary new.
+	normalValues := Dictionary new.
+	allKeys := Set new.
+
+	outlierTests do: [ :test | | values |
+		values := valueBlock value: test.
+		values keysAndValuesDo: [ :key :val |
+			allKeys add: key.
+			outlierValues at: key put: (outlierValues at: key ifAbsent: [ 0 ]) + val ] ].
+
+	outlierTests ifNotEmpty: [
+		outlierValues keysAndValuesDo: [ :key :sum |
+			outlierValues at: key put: sum / outlierTests size ] ].
+
+	normalTests do: [ :test | | values |
+		values := valueBlock value: test.
+		values keysAndValuesDo: [ :key :val |
+			allKeys add: key.
+			normalValues at: key put: (normalValues at: key ifAbsent: [ 0 ]) + val ] ].
+
+	normalTests ifNotEmpty: [
+		normalValues keysAndValuesDo: [ :key :sum |
+			normalValues at: key put: sum / normalTests size ] ].
+
+	deltas := Dictionary new.
+	allKeys do: [ :key |
+		| outlierAvg normalAvg delta |
+		outlierAvg := outlierValues at: key ifAbsent: [ 0.0 ].
+		normalAvg := normalValues at: key ifAbsent: [ 0.0 ].
+		delta := outlierAvg - normalAvg.
+		delta > 0 ifTrue: [ deltas at: key put: delta ] ].
+
+	^ deltas
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localize: aUmeResult [
+
+	result := aUmeResult.
+	reports := OrderedCollection new.
+
+	self localizeErrors.
+	self localizeFailures.
+	self localizePerformanceOutliers.
+
+	^ reports
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizeErrors [
+
+	result tests do: [ :test |
+		(test result isKindOf: UmeEvalError) ifTrue: [ | report topFrames |
+			report := UmeBugReport for: test type: #error.
+			report errorMessage: test result message.
+
+			test result stack ifNotNil: [ :frames |
+				report stackTrace: frames.
+				topFrames := frames first: ((frames size) min: 3).
+				report suspectedMethods: (topFrames collect: [ :frame | frame asString ]) asOrderedCollection ].
+
+			test result coverageResult ifNotNil: [ :cov |
+				report executedMethods: cov methods.
+				report uncoveredMethods: cov uncoveredMethods ].
+
+			reports add: report ] ]
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizeFailures [
+
+	| failingTests passingTests suspiciousness |
+	failingTests := result tests select: [ :t | t result isKindOf: UmeEvalFail ].
+	failingTests ifEmpty: [ ^ self ].
+
+	passingTests := result tests select: [ :t | t result isKindOf: UmeEvalSuccess ].
+	passingTests ifEmpty: [ ^ self ].
+
+	suspiciousness := self computeOchiaiForPassing: passingTests failing: failingTests.
+	suspiciousness ifEmpty: [ ^ self ].
+
+	failingTests do: [ :test |
+		| report orderedSuspects |
+		report := UmeBugReport for: test type: #propertyFail.
+		report suspiciousnessScores: suspiciousness.
+
+		orderedSuspects := (suspiciousness keys asSortedCollection: [ :a :b |
+			(suspiciousness at: a) > (suspiciousness at: b) ]) asOrderedCollection.
+		report suspectedMethods: orderedSuspects.
+
+		test result coverageResult ifNotNil: [ :cov |
+			report executedMethods: cov methods.
+			report uncoveredMethods: cov uncoveredMethods ].
+
+		reports add: report ]
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizePerformanceOutliers [
+
+	self localizePerformanceOutliersByExecutionTime.
+	self localizePerformanceOutliersByMemory.
+	self localizePerformanceOutliersByCoverage.
+	self localizePerformanceOutliersByScore
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizePerformanceOutliersByExecutionTime [
+
+	| outlierTests normalTests deltas |
+	outlierTests := result outliersByExecutionTime.
+	outlierTests ifEmpty: [ ^ self ].
+
+	normalTests := result tests select: [ :t |
+		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
+	normalTests ifEmpty: [ ^ self ].
+
+	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
+		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
+			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
+
+	deltas ifEmpty: [ ^ self ].
+
+	outlierTests do: [ :test |
+		| report orderedSuspects |
+		report := UmeBugReport for: test type: #performanceOutlier.
+		report metric: #executionTime.
+		report suspiciousnessScores: deltas.
+
+		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
+			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
+		report suspectedMethods: orderedSuspects.
+
+		test result coverageResult ifNotNil: [ :cov |
+			report executedMethods: cov methods ].
+
+		reports add: report ]
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizePerformanceOutliersByMemory [
+
+	| outlierTests normalTests deltas |
+	outlierTests := result outliersByAllocatedMemory.
+	outlierTests ifEmpty: [ ^ self ].
+
+	normalTests := result tests select: [ :t |
+		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
+	normalTests ifEmpty: [ ^ self ].
+
+	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
+		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
+			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
+
+	deltas ifEmpty: [ ^ self ].
+
+	outlierTests do: [ :test |
+		| report orderedSuspects |
+		report := UmeBugReport for: test type: #performanceOutlier.
+		report metric: #allocatedMemory.
+		report suspiciousnessScores: deltas.
+
+		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
+			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
+		report suspectedMethods: orderedSuspects.
+
+		test result coverageResult ifNotNil: [ :cov |
+			report executedMethods: cov methods ].
+
+		reports add: report ]
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizePerformanceOutliersByCoverage [
+
+	| outlierTests normalTests deltas |
+	outlierTests := result outliersByCoverage.
+	outlierTests ifEmpty: [ ^ self ].
+
+	normalTests := result tests select: [ :t |
+		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
+	normalTests ifEmpty: [ ^ self ].
+
+	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
+		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
+			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
+
+	deltas ifEmpty: [ ^ self ].
+
+	outlierTests do: [ :test |
+		| report orderedSuspects |
+		report := UmeBugReport for: test type: #performanceOutlier.
+		report metric: #coverage.
+		report suspiciousnessScores: deltas.
+
+		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
+			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
+		report suspectedMethods: orderedSuspects.
+
+		test result coverageResult ifNotNil: [ :cov |
+			report executedMethods: cov methods ].
+
+		reports add: report ]
+]
+
+{ #category : 'localization' }
+UmeBugLocalizer >> localizePerformanceOutliersByScore [
+
+	| outlierTests normalTests deltas |
+	outlierTests := result outliersByScore.
+	outlierTests ifEmpty: [ ^ self ].
+
+	normalTests := result tests select: [ :t |
+		(outlierTests includes: t) not and: [ t result isKindOf: UmeEvalSuccess ] ].
+	normalTests ifEmpty: [ ^ self ].
+
+	deltas := self computeProfilingDeltaForOutliers: outlierTests normal: normalTests valueBlock: [ :test |
+		test result profilingResult ifNil: [ Dictionary new ] ifNotNil: [ :pr |
+			(pr respondsTo: #methodsCalled) ifTrue: [ pr methodsCalled ] ifFalse: [ Dictionary new ] ] ].
+
+	deltas ifEmpty: [ ^ self ].
+
+	outlierTests do: [ :test |
+		| report orderedSuspects |
+		report := UmeBugReport for: test type: #performanceOutlier.
+		report metric: #score.
+		report suspiciousnessScores: deltas.
+
+		orderedSuspects := (deltas keys asSortedCollection: [ :a :b |
+			(deltas at: a) > (deltas at: b) ]) asOrderedCollection.
+		report suspectedMethods: orderedSuspects.
+
+		test result coverageResult ifNotNil: [ :cov |
+			report executedMethods: cov methods ].
+
+		reports add: report ]
+]
+
+{ #category : 'accessing' }
+UmeBugLocalizer >> reports [
+
+	^ reports
+]
+
+{ #category : 'accessing' }
+UmeBugLocalizer >> result [
+
+	^ result
+]
+
+{ #category : 'accessing' }
+UmeBugLocalizer >> result: aUmeResult [
+
+	result := aUmeResult
+]

--- a/Ume/UmeBugReport.class.st
+++ b/Ume/UmeBugReport.class.st
@@ -69,20 +69,6 @@ UmeBugReport class >> outlierBaseline: baseline [
 ]
 
 { #category : 'instance creation' }
-UmeBugReport class >> outlierReport: test delta: delta suspectedMethods: suspectedMethods [
-
-	| bug |
-	
-	bug := UmeOutlierBugReport new test: test.
-	bug delta: delta.
-	bug suspectedMethods: suspectedMethods.
-
-	test result coverageResult ifNotNil: [ :cov | bug executedMethods: cov methods ].
-
-	^ bug
-]
-
-{ #category : 'instance creation' }
 UmeBugReport class >> outlierReport: test delta: delta suspectedMethods: deltaMethods suspectedNodes: deltaNodes [
 
 	| bug |

--- a/Ume/UmeBugReport.class.st
+++ b/Ume/UmeBugReport.class.st
@@ -52,6 +52,24 @@ UmeBugReport class >> failReport: test from: suspiciousness [
 ]
 
 { #category : 'instance creation' }
+UmeBugReport class >> outlierBaseline: baseline [
+
+	| bug |
+	
+	bug := UmeOutlierBaseline new test: baseline.
+
+	bug delta: baseline feedback values.
+
+	baseline result coverageResult ifNotNil: [ :cov |
+		bug executedMethods: cov methods.
+		bug suspectedMethods: cov methods.
+		bug suspectedNodes: cov nodes.
+	].
+
+	^ bug
+]
+
+{ #category : 'instance creation' }
 UmeBugReport class >> outlierReport: test delta: delta suspectedMethods: suspectedMethods [
 
 	| bug |

--- a/Ume/UmeBugReport.class.st
+++ b/Ume/UmeBugReport.class.st
@@ -21,11 +21,10 @@ UmeBugReport class >> errorReport: test [
 	bug errorMessage: test result message.
 
 	test result stack ifNotNil: [ :frames |
-			bug stackTrace: frames.
-			topFrames := frames first: (frames size min: 3).
-			bug suspectedMethods:
-				(topFrames collect: [ :frame | frame asString ])
-					asOrderedCollection ].
+		bug stackTrace: frames.
+		topFrames := frames first: (frames size min: 3).
+		bug suspectedMethods: (topFrames collect: [ :frame | frame method ])
+	].
 
 	test result coverageResult ifNotNil: [ :cov | bug executedMethods: cov methods ].
 	

--- a/Ume/UmeBugReport.class.st
+++ b/Ume/UmeBugReport.class.st
@@ -1,0 +1,149 @@
+Class {
+	#name : 'UmeBugReport',
+	#superclass : 'Object',
+	#instVars : [
+		'type',
+		'test',
+		'metric',
+		'suspectedMethods',
+		'suspiciousnessScores',
+		'stackTrace',
+		'errorMessage',
+		'executedMethods',
+		'uncoveredMethods'
+	],
+	#category : 'Ume-Localization',
+	#package : 'Ume',
+	#tag : 'Localization'
+}
+
+{ #category : 'instance creation' }
+UmeBugReport class >> for: aTest type: aSymbol [
+	^ self new
+		test: aTest;
+		type: aSymbol;
+		yourself
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> errorMessage [
+
+	^ errorMessage
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> errorMessage: aString [
+
+	errorMessage := aString
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> executedMethods [
+
+	^ executedMethods
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> executedMethods: aSet [
+
+	executedMethods := aSet
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> metric [
+
+	^ metric
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> metric: aSymbol [
+
+	metric := aSymbol
+]
+
+{ #category : 'printing' }
+UmeBugReport >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		nextPutAll: ' type: ';
+		nextPutAll: type asString.
+	metric ifNotNil: [ aStream nextPutAll: ' metric: '; nextPutAll: metric asString ].
+	aStream nextPutAll: ' test: '; print: test name.
+	suspectedMethods ifNotNil: [ :methods |
+		aStream nextPutAll: ' top suspect: '.
+		methods ifEmpty: [ aStream nextPutAll: '(none)' ] ifNotEmpty: [ aStream print: methods first ] ].
+	errorMessage ifNotNil: [ aStream nextPutAll: ' error: '; nextPutAll: errorMessage ]
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> stackTrace [
+
+	^ stackTrace
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> stackTrace: aCollection [
+
+	stackTrace := aCollection
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> suspectedMethods [
+
+	^ suspectedMethods
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> suspectedMethods: anOrderedCollection [
+
+	suspectedMethods := anOrderedCollection
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> suspiciousnessScores [
+
+	^ suspiciousnessScores
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> suspiciousnessScores: aDictionary [
+
+	suspiciousnessScores := aDictionary
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> test [
+
+	^ test
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> test: aUmeTest [
+
+	test := aUmeTest
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> type [
+
+	^ type
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> type: aSymbol [
+
+	type := aSymbol
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> uncoveredMethods [
+
+	^ uncoveredMethods
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> uncoveredMethods: aSet [
+
+	uncoveredMethods := aSet
+]

--- a/Ume/UmeBugReport.class.st
+++ b/Ume/UmeBugReport.class.st
@@ -18,6 +18,51 @@ Class {
 }
 
 { #category : 'instance creation' }
+UmeBugReport class >> errorReport: test [
+
+	| bug topFrames |
+
+	bug := self new test: test; type: #error.
+
+	bug errorMessage: test result message.
+
+	test result stack ifNotNil: [ :frames |
+			bug stackTrace: frames.
+			topFrames := frames first: (frames size min: 3).
+			bug suspectedMethods:
+				(topFrames collect: [ :frame | frame asString ])
+					asOrderedCollection ].
+
+	test result coverageResult ifNotNil: [ :cov |
+			bug executedMethods: cov methods.
+			bug uncoveredMethods: cov uncoveredMethods ].
+	^ bug
+]
+
+{ #category : 'instance creation' }
+UmeBugReport class >> failReport: test from: suspiciousness [
+
+	| bug orderedSuspects |
+
+	bug := self new
+		       test: test;
+		       type: #propertyFail.
+	bug suspiciousnessScores: suspiciousness.
+
+	orderedSuspects := (suspiciousness keys asSortedCollection: [ :a :b |
+		                    (suspiciousness at: a) > (suspiciousness at: b) ])
+		                   asOrderedCollection.
+
+	bug suspectedMethods: orderedSuspects.
+
+	test result coverageResult ifNotNil: [ :cov |
+			bug executedMethods: cov methods.
+			bug uncoveredMethods: cov uncoveredMethods ].
+
+	^ bug
+]
+
+{ #category : 'instance creation' }
 UmeBugReport class >> for: aTest type: aSymbol [
 	^ self new
 		test: aTest;

--- a/Ume/UmeBugReport.class.st
+++ b/Ume/UmeBugReport.class.st
@@ -2,15 +2,11 @@ Class {
 	#name : 'UmeBugReport',
 	#superclass : 'Object',
 	#instVars : [
-		'type',
 		'test',
 		'metric',
 		'suspectedMethods',
-		'suspiciousnessScores',
-		'stackTrace',
-		'errorMessage',
-		'executedMethods',
-		'uncoveredMethods'
+		'delta',
+		'executedMethods'
 	],
 	#category : 'Ume-Localization',
 	#package : 'Ume',
@@ -22,8 +18,7 @@ UmeBugReport class >> errorReport: test [
 
 	| bug topFrames |
 
-	bug := self new test: test; type: #error.
-
+	bug := UmeErrorBugReport new test: test.
 	bug errorMessage: test result message.
 
 	test result stack ifNotNil: [ :frames |
@@ -33,9 +28,8 @@ UmeBugReport class >> errorReport: test [
 				(topFrames collect: [ :frame | frame asString ])
 					asOrderedCollection ].
 
-	test result coverageResult ifNotNil: [ :cov |
-			bug executedMethods: cov methods.
-			bug uncoveredMethods: cov uncoveredMethods ].
+	test result coverageResult ifNotNil: [ :cov | bug executedMethods: cov methods ].
+	
 	^ bug
 ]
 
@@ -44,10 +38,8 @@ UmeBugReport class >> failReport: test from: suspiciousness [
 
 	| bug orderedSuspects |
 
-	bug := self new
-		       test: test;
-		       type: #propertyFail.
-	bug suspiciousnessScores: suspiciousness.
+	bug := UmeFailBugReport new test: test.
+	bug delta: suspiciousness.
 
 	orderedSuspects := (suspiciousness keys asSortedCollection: [ :a :b |
 		                    (suspiciousness at: a) > (suspiciousness at: b) ])
@@ -55,31 +47,56 @@ UmeBugReport class >> failReport: test from: suspiciousness [
 
 	bug suspectedMethods: orderedSuspects.
 
-	test result coverageResult ifNotNil: [ :cov |
-			bug executedMethods: cov methods.
-			bug uncoveredMethods: cov uncoveredMethods ].
+	test result coverageResult ifNotNil: [ :cov | bug executedMethods: cov methods ].
 
 	^ bug
 ]
 
 { #category : 'instance creation' }
-UmeBugReport class >> for: aTest type: aSymbol [
-	^ self new
-		test: aTest;
-		type: aSymbol;
-		yourself
+UmeBugReport class >> outlierReport: test delta: delta suspectedMethods: suspectedMethods [
+
+	| bug |
+	
+	bug := UmeOutlierBugReport new test: test.
+	bug delta: delta.
+	bug suspectedMethods: suspectedMethods.
+
+	test result coverageResult ifNotNil: [ :cov | bug executedMethods: cov methods ].
+
+	^ bug
+]
+
+{ #category : 'instance creation' }
+UmeBugReport class >> outlierReport: test delta: delta suspectedMethods: deltaMethods suspectedNodes: deltaNodes [
+
+	| bug |
+	
+	bug := UmeOutlierBugReport new test: test.
+	bug delta: delta.
+	bug suspectedMethods: deltaMethods.
+	bug suspectedNodes: deltaNodes.
+
+	test result coverageResult ifNotNil: [ :cov | bug executedMethods: cov methods ].
+
+	^ bug
 ]
 
 { #category : 'accessing' }
+UmeBugReport >> delta [
+
+	^ delta
+]
+
+{ #category : 'accessing' }
+UmeBugReport >> delta: aDelta [
+
+	delta := aDelta
+]
+
+{ #category : 'printing' }
 UmeBugReport >> errorMessage [
 
-	^ errorMessage
-]
-
-{ #category : 'accessing' }
-UmeBugReport >> errorMessage: aString [
-
-	errorMessage := aString
+	^ nil
 ]
 
 { #category : 'accessing' }
@@ -94,43 +111,19 @@ UmeBugReport >> executedMethods: aSet [
 	executedMethods := aSet
 ]
 
-{ #category : 'accessing' }
-UmeBugReport >> metric [
-
-	^ metric
-]
-
-{ #category : 'accessing' }
-UmeBugReport >> metric: aSymbol [
-
-	metric := aSymbol
-]
-
 { #category : 'printing' }
 UmeBugReport >> printOn: aStream [
 
 	super printOn: aStream.
 	aStream
 		nextPutAll: ' type: ';
-		nextPutAll: type asString.
+		nextPutAll: self type asString.
 	metric ifNotNil: [ aStream nextPutAll: ' metric: '; nextPutAll: metric asString ].
 	aStream nextPutAll: ' test: '; print: test name.
 	suspectedMethods ifNotNil: [ :methods |
 		aStream nextPutAll: ' top suspect: '.
 		methods ifEmpty: [ aStream nextPutAll: '(none)' ] ifNotEmpty: [ aStream print: methods first ] ].
-	errorMessage ifNotNil: [ aStream nextPutAll: ' error: '; nextPutAll: errorMessage ]
-]
-
-{ #category : 'accessing' }
-UmeBugReport >> stackTrace [
-
-	^ stackTrace
-]
-
-{ #category : 'accessing' }
-UmeBugReport >> stackTrace: aCollection [
-
-	stackTrace := aCollection
+	self errorMessage ifNotNil: [ aStream nextPutAll: ' error: '; nextPutAll: self errorMessage ]
 ]
 
 { #category : 'accessing' }
@@ -146,18 +139,6 @@ UmeBugReport >> suspectedMethods: anOrderedCollection [
 ]
 
 { #category : 'accessing' }
-UmeBugReport >> suspiciousnessScores [
-
-	^ suspiciousnessScores
-]
-
-{ #category : 'accessing' }
-UmeBugReport >> suspiciousnessScores: aDictionary [
-
-	suspiciousnessScores := aDictionary
-]
-
-{ #category : 'accessing' }
 UmeBugReport >> test [
 
 	^ test
@@ -167,28 +148,4 @@ UmeBugReport >> test [
 UmeBugReport >> test: aUmeTest [
 
 	test := aUmeTest
-]
-
-{ #category : 'accessing' }
-UmeBugReport >> type [
-
-	^ type
-]
-
-{ #category : 'accessing' }
-UmeBugReport >> type: aSymbol [
-
-	type := aSymbol
-]
-
-{ #category : 'accessing' }
-UmeBugReport >> uncoveredMethods [
-
-	^ uncoveredMethods
-]
-
-{ #category : 'accessing' }
-UmeBugReport >> uncoveredMethods: aSet [
-
-	uncoveredMethods := aSet
 ]

--- a/Ume/UmeBugReport.class.st
+++ b/Ume/UmeBugReport.class.st
@@ -83,6 +83,12 @@ UmeBugReport class >> outlierReport: test delta: delta suspectedMethods: deltaMe
 	^ bug
 ]
 
+{ #category : 'as yet unclassified' }
+UmeBugReport >> bugId [
+
+	self subclassResponsibility 
+]
+
 { #category : 'accessing' }
 UmeBugReport >> delta [
 

--- a/Ume/UmeBugReport.class.st
+++ b/Ume/UmeBugReport.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'test',
-		'metric',
 		'suspectedMethods',
 		'delta',
 		'executedMethods'
@@ -109,21 +108,6 @@ UmeBugReport >> executedMethods [
 UmeBugReport >> executedMethods: aSet [
 
 	executedMethods := aSet
-]
-
-{ #category : 'printing' }
-UmeBugReport >> printOn: aStream [
-
-	super printOn: aStream.
-	aStream
-		nextPutAll: ' type: ';
-		nextPutAll: self type asString.
-	metric ifNotNil: [ aStream nextPutAll: ' metric: '; nextPutAll: metric asString ].
-	aStream nextPutAll: ' test: '; print: test name.
-	suspectedMethods ifNotNil: [ :methods |
-		aStream nextPutAll: ' top suspect: '.
-		methods ifEmpty: [ aStream nextPutAll: '(none)' ] ifNotEmpty: [ aStream print: methods first ] ].
-	self errorMessage ifNotNil: [ aStream nextPutAll: ' error: '; nextPutAll: self errorMessage ]
 ]
 
 { #category : 'accessing' }

--- a/Ume/UmeErrorBugReport.class.st
+++ b/Ume/UmeErrorBugReport.class.st
@@ -10,6 +10,12 @@ Class {
 	#tag : 'Localization'
 }
 
+{ #category : 'as yet unclassified' }
+UmeErrorBugReport >> bugId [
+
+	^ errorMessage
+]
+
 { #category : 'accessing' }
 UmeErrorBugReport >> errorMessage [
 

--- a/Ume/UmeErrorBugReport.class.st
+++ b/Ume/UmeErrorBugReport.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : 'UmeErrorBugReport',
+	#superclass : 'UmeBugReport',
+	#instVars : [
+		'stackTrace',
+		'errorMessage'
+	],
+	#category : 'Ume-Localization',
+	#package : 'Ume',
+	#tag : 'Localization'
+}
+
+{ #category : 'accessing' }
+UmeErrorBugReport >> errorMessage [
+
+	^ errorMessage
+]
+
+{ #category : 'accessing' }
+UmeErrorBugReport >> errorMessage: message [
+
+	errorMessage := message
+]
+
+{ #category : 'accessing' }
+UmeErrorBugReport >> stackTrace [
+
+	^ stackTrace
+]
+
+{ #category : 'accessing' }
+UmeErrorBugReport >> stackTrace: trace [
+
+	stackTrace := trace
+]
+
+{ #category : 'accessing' }
+UmeErrorBugReport >> type [
+
+	^ #errorBug
+]

--- a/Ume/UmeEvalFail.class.st
+++ b/Ume/UmeEvalFail.class.st
@@ -5,3 +5,9 @@ Class {
 	#package : 'Ume',
 	#tag : 'Evaluation'
 }
+
+{ #category : 'testing' }
+UmeEvalFail >> isFail [
+
+	^ true
+]

--- a/Ume/UmeEvalResult.class.st
+++ b/Ume/UmeEvalResult.class.st
@@ -52,6 +52,18 @@ UmeEvalResult >> isError [
 	^ false
 ]
 
+{ #category : 'testing' }
+UmeEvalResult >> isFail [
+
+	^ false
+]
+
+{ #category : 'testing' }
+UmeEvalResult >> isSuccess [
+
+	^ false
+]
+
 { #category : 'accessing' }
 UmeEvalResult >> profilingResult [
 

--- a/Ume/UmeEvalSuccess.class.st
+++ b/Ume/UmeEvalSuccess.class.st
@@ -11,3 +11,9 @@ UmeEvalSuccess class >> stonAllInstVarNames [
 
 	^ super stonAllInstVarNames copyWithoutAll: #( )
 ]
+
+{ #category : 'testing' }
+UmeEvalSuccess >> isSuccess [
+
+	^ true
+]

--- a/Ume/UmeEvaluator.class.st
+++ b/Ume/UmeEvaluator.class.st
@@ -55,7 +55,7 @@ UmeEvaluator >> eval: receiver method: methodToPerform from: schema with: args a
 			stack: (error signalerContext stackOfSize: 10);
 			profilingResult: profilingResult;
 			coverageResult: localCoverageResult;
-			message: self asString"error messageText"
+			message: error asString
 	].
 
 	^ (assertResult ifTrue: [ UmeEvalSuccess ] ifFalse: [ UmeEvalFail ]) new

--- a/Ume/UmeFailBugReport.class.st
+++ b/Ume/UmeFailBugReport.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'UmeFailBugReport',
+	#superclass : 'UmeBugReport',
+	#category : 'Ume-Localization',
+	#package : 'Ume',
+	#tag : 'Localization'
+}
+
+{ #category : 'accessing' }
+UmeFailBugReport >> type [
+
+	^ #failBug
+]

--- a/Ume/UmeOutlierBaseline.class.st
+++ b/Ume/UmeOutlierBaseline.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'UmeOutlierBaseline',
+	#superclass : 'UmeOutlierBugReport',
+	#category : 'Ume-Localization',
+	#package : 'Ume',
+	#tag : 'Localization'
+}

--- a/Ume/UmeOutlierBaseline.class.st
+++ b/Ume/UmeOutlierBaseline.class.st
@@ -5,3 +5,9 @@ Class {
 	#package : 'Ume',
 	#tag : 'Localization'
 }
+
+{ #category : 'as yet unclassified' }
+UmeOutlierBaseline >> bugId [
+
+	^ 'Baseline'
+]

--- a/Ume/UmeOutlierBugReport.class.st
+++ b/Ume/UmeOutlierBugReport.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : 'UmeOutlierBugReport',
+	#superclass : 'UmeBugReport',
+	#instVars : [
+		'suspectedNodes'
+	],
+	#category : 'Ume-Localization',
+	#package : 'Ume',
+	#tag : 'Localization'
+}
+
+{ #category : 'accessing' }
+UmeOutlierBugReport >> suspectedNodes [
+
+	^ suspectedNodes
+]
+
+{ #category : 'accessing' }
+UmeOutlierBugReport >> suspectedNodes: nodes [
+
+	suspectedNodes := nodes
+]
+
+{ #category : 'accessing' }
+UmeOutlierBugReport >> type [
+
+	^ #outlierBug
+]

--- a/Ume/UmeOutlierBugReport.class.st
+++ b/Ume/UmeOutlierBugReport.class.st
@@ -9,6 +9,12 @@ Class {
 	#tag : 'Localization'
 }
 
+{ #category : 'as yet unclassified' }
+UmeOutlierBugReport >> bugId [
+
+	^ suspectedNodes asString
+]
+
 { #category : 'accessing' }
 UmeOutlierBugReport >> suspectedNodes [
 

--- a/Ume/UmeResult.class.st
+++ b/Ume/UmeResult.class.st
@@ -18,6 +18,64 @@ Class {
 	#tag : 'Result'
 }
 
+{ #category : 'localization' }
+UmeResult >> generateBugReport [
+
+	| localizer reportStream categories |
+	localizer := UmeBugLocalizer on: self.
+	localizer localize: self.
+	localizer reports ifEmpty: [ ^ 'No bugs or outliers found to localize.' ].
+
+	reportStream := String new writeStream.
+	reportStream
+		nextPutAll: '=== Ume Bug Localization Report ===';
+		cr; nextPutAll: 'Total test cases: '; print: tests size; cr;
+		nextPutAll: 'Top cases (interesting): '; print: topCases size; cr;
+		cr.
+
+	categories := (localizer reports collect: #type) asSet sorted.
+	categories do: [ :catType |
+		| catReports |
+		catReports := localizer reports select: [ :r | r type = catType ].
+		reportStream
+			nextPutAll: '--- '; nextPutAll: catType asString; nextPutAll: ' ('; print: catReports size; nextPutAll: ' cases) ---'; cr.
+		catReports doWithIndex: [ :report :idx |
+			reportStream
+				nextPutAll: '  '; print: idx; nextPutAll: '. Test: '; print: report test name; cr.
+			report errorMessage ifNotNil: [ :msg |
+				reportStream nextPutAll: '     Error: '; nextPutAll: msg; cr ].
+			report metric ifNotNil: [ :m |
+				reportStream nextPutAll: '     Metric: '; nextPutAll: m asString; cr ].
+			report suspectedMethods ifNotNil: [ :methods |
+				reportStream nextPutAll: '     Top suspects:'; cr.
+				(methods first: (methods size min: 5)) do: [ :method |
+					| scoreStr |
+					scoreStr := report suspiciousnessScores
+						ifNotNil: [ (report suspiciousnessScores at: method ifAbsent: [ 0.0 ]) printString ]
+						ifNil: [ 'n/a' ].
+					reportStream
+						tab; tab; print: method;
+						nextPutAll: ' (score: '; nextPutAll: scoreStr; nextPutAll: ')'; cr ] ].
+			report stackTrace ifNotNil: [ :stack |
+				reportStream nextPutAll: '     Stack (top 3):'; cr.
+				(stack first: (stack size min: 3)) do: [ :frame |
+					reportStream tab; tab; nextPutAll: frame asString; cr ] ].
+			report executedMethods ifNotNil: [ :exec |
+				reportStream nextPutAll: '     Methods executed: '; print: exec size; cr ].
+			cr ] ].
+
+	reportStream
+		cr; nextPutAll: '=== End of Report ==='; cr.
+
+	^ reportStream contents
+]
+
+{ #category : 'localization' }
+UmeResult >> localizeBugs [
+
+	^ (UmeBugLocalizer on: self) localize: self
+]
+
 { #category : 'as yet unclassified' }
 UmeResult class >> resultFrom: tests since: time withCoverage: totalCoverageResult runner: runner [
 

--- a/Ume/UmeResult.class.st
+++ b/Ume/UmeResult.class.st
@@ -11,70 +11,13 @@ Class {
 		'ranking',
 		'topCases',
 		'feedbackEvaluator',
-		'runner'
+		'runner',
+		'localizedBugs'
 	],
 	#category : 'Ume-Result',
 	#package : 'Ume',
 	#tag : 'Result'
 }
-
-{ #category : 'localization' }
-UmeResult >> generateBugReport [
-
-	| localizer reportStream categories |
-	localizer := UmeBugLocalizer on: self.
-	localizer localize: self.
-	localizer reports ifEmpty: [ ^ 'No bugs or outliers found to localize.' ].
-
-	reportStream := String new writeStream.
-	reportStream
-		nextPutAll: '=== Ume Bug Localization Report ===';
-		cr; nextPutAll: 'Total test cases: '; print: tests size; cr;
-		nextPutAll: 'Top cases (interesting): '; print: topCases size; cr;
-		cr.
-
-	categories := (localizer reports collect: #type) asSet sorted.
-	categories do: [ :catType |
-		| catReports |
-		catReports := localizer reports select: [ :r | r type = catType ].
-		reportStream
-			nextPutAll: '--- '; nextPutAll: catType asString; nextPutAll: ' ('; print: catReports size; nextPutAll: ' cases) ---'; cr.
-		catReports doWithIndex: [ :report :idx |
-			reportStream
-				nextPutAll: '  '; print: idx; nextPutAll: '. Test: '; print: report test name; cr.
-			report errorMessage ifNotNil: [ :msg |
-				reportStream nextPutAll: '     Error: '; nextPutAll: msg; cr ].
-			report metric ifNotNil: [ :m |
-				reportStream nextPutAll: '     Metric: '; nextPutAll: m asString; cr ].
-			report suspectedMethods ifNotNil: [ :methods |
-				reportStream nextPutAll: '     Top suspects:'; cr.
-				(methods first: (methods size min: 5)) do: [ :method |
-					| scoreStr |
-					scoreStr := report suspiciousnessScores
-						ifNotNil: [ (report suspiciousnessScores at: method ifAbsent: [ 0.0 ]) printString ]
-						ifNil: [ 'n/a' ].
-					reportStream
-						tab; tab; print: method;
-						nextPutAll: ' (score: '; nextPutAll: scoreStr; nextPutAll: ')'; cr ] ].
-			report stackTrace ifNotNil: [ :stack |
-				reportStream nextPutAll: '     Stack (top 3):'; cr.
-				(stack first: (stack size min: 3)) do: [ :frame |
-					reportStream tab; tab; nextPutAll: frame asString; cr ] ].
-			report executedMethods ifNotNil: [ :exec |
-				reportStream nextPutAll: '     Methods executed: '; print: exec size; cr ].
-			cr ] ].
-
-	reportStream
-		cr; nextPutAll: '=== End of Report ==='; cr.
-
-	^ reportStream contents
-]
-
-{ #category : 'localization' }
-UmeResult >> localizeBugs [
-
-	^ (UmeBugLocalizer on: self) localize: self
-]
 
 { #category : 'as yet unclassified' }
 UmeResult class >> resultFrom: tests since: time withCoverage: totalCoverageResult runner: runner [
@@ -92,12 +35,12 @@ UmeResult class >> resultFrom: tests since: time withCoverage: totalCoverageResu
 		runner: runner;
 		feedbackEvaluator: runner feedbackEvaluator;
 		ranking: (tests collect: [ :test | test score ifNil: [ 0 ] ifNotNil: [ test score ] ]) asSortedCollection reverse;
+		localizeBugs;
 		performanceResult: perfResult
 ]
 
 { #category : 'as yet unclassified' }
 UmeResult class >> resultFrom: tests since: time withCoverage: totalCoverageResult runner: runner with: aNumberOfTest [
-
 	
 	^ (self resultFrom: tests since: time  withCoverage: totalCoverageResult  runner: runner) numberOfGeneratedTests: aNumberOfTest 
 ]
@@ -196,6 +139,14 @@ UmeResult >> lineplotBy: xBlock and: ybloc xlabel: xLabel ylabel: yLabel title: 
 		  ylabel: yLabel;
 		  title: title;
 		  open
+]
+
+{ #category : 'localization' }
+UmeResult >> localizeBugs [
+
+	localizedBugs ifNil: [ localizedBugs := UmeBugLocalizer localize: self ].
+
+	^ localizedBugs
 ]
 
 { #category : 'as yet unclassified' }

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -2,14 +2,7 @@ Class {
 	#name : 'UmeShrinker',
 	#superclass : 'Object',
 	#instVars : [
-		'maxIterations',
-		'grammar',
-		'evaluator',
-		'feedbackEvaluator',
-		'threshold',
-		'programBlock',
-		'classesToProfile',
-		'memo'
+		'maxIterations'
 	],
 	#category : 'Ume-Shrinking',
 	#package : 'Ume',


### PR DESCRIPTION
## Bug Localization

This PR introduces bug localization logic to identify the cause of each error/failure, or outlier.

We iterate over all the generated tests, and we decouple them by `Errors`, `Failures`, or `Performance Outlier`.

Each case would generate a Bug Report that provides all relevant information about its cause.

- **Error Bug Report** will provide the error message, its stack trace, as well as the suspected cause methods.
- **Failures Bug  Report** will represent a test case that does not satisfy the property.
- **Outlier Bug Report** will provide the profiling result delta ( compared with the last better case before it ), as well as the suspected cause nodes ( to have more granularity ).

Note: the outlier report does not consider the first test case; it is used as the baseline for the whole generation.

All the reports provide information about the test case and the methods executed for that test case.


