### PR TITLE
Shrinking benchmarking

### DIFF
--- a/Ume/AritExpressionGrammar.class.st
+++ b/Ume/AritExpressionGrammar.class.st
@@ -26,11 +26,11 @@ AritExpressionGrammar >> defineGrammar [
     
     ntFactor --> ntInt | '(', ntExpr, ')'.
     
-    ntInt --> ntDigit.
+    ntInt --> ntDigit | ntDigit, ntInt.
     
     ntDigit --> ($0 - $9).
     
-    ntOp --> '+' | '*'.
+    ntOp --> '+' | '*' | '/' | '-'.
     
     ^ ntStart 
 ]

--- a/Ume/DivideZeroOracle.class.st
+++ b/Ume/DivideZeroOracle.class.st
@@ -7,7 +7,7 @@ Class {
 }
 
 { #category : 'as yet unclassified' }
-DivideZeroOracle >> isAccepted: input [
+DivideZeroOracle >> accepts: input from: _ [ 
 
 	[
 		OpalCompiler new

--- a/Ume/DivideZeroOracle.class.st
+++ b/Ume/DivideZeroOracle.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'DivideZeroOracle',
+	#superclass : 'UmeInputOracle',
+	#category : 'Ume-Shrinking',
+	#package : 'Ume',
+	#tag : 'Shrinking'
+}
+
+{ #category : 'as yet unclassified' }
+DivideZeroOracle >> isAccepted: input [
+
+	[
+		OpalCompiler new
+			source: input;
+			evaluate ]
+		on: Error
+		do: [ :error | ^ error isKindOf: ZeroDivide ].
+
+	^ false
+]
+
+{ #category : 'as yet unclassified' }
+DivideZeroOracle >> problemPresence: bound [
+
+	^ bound ifTrue: [ 100 ] ifFalse: [ 0 ]
+]

--- a/Ume/ShrinkerTest.class.st
+++ b/Ume/ShrinkerTest.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'ShrinkerTest',
+	#superclass : 'Object',
+	#category : 'Ume-Shrinking',
+	#package : 'Ume',
+	#tag : 'Shrinking'
+}

--- a/Ume/ShrinkerTest.class.st
+++ b/Ume/ShrinkerTest.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : 'as yet unclassified' }
 ShrinkerTest class >> input: input oracle: oracle [
 
-	^ self new input: input oracle: oracle
+	^ self new input: input; oracle: oracle
 ]
 
 { #category : 'accessing' }

--- a/Ume/ShrinkerTest.class.st
+++ b/Ume/ShrinkerTest.class.st
@@ -1,7 +1,41 @@
 Class {
 	#name : 'ShrinkerTest',
 	#superclass : 'Object',
+	#instVars : [
+		'input',
+		'oracle'
+	],
 	#category : 'Ume-Shrinking',
 	#package : 'Ume',
 	#tag : 'Shrinking'
 }
+
+{ #category : 'as yet unclassified' }
+ShrinkerTest class >> input: input oracle: oracle [
+
+	^ self new input: input oracle: oracle
+]
+
+{ #category : 'accessing' }
+ShrinkerTest >> input [
+
+	^ input
+]
+
+{ #category : 'accessing' }
+ShrinkerTest >> input: anInput [
+
+	input := anInput 
+]
+
+{ #category : 'accessing' }
+ShrinkerTest >> oracle [
+
+	^ oracle
+]
+
+{ #category : 'accessing' }
+ShrinkerTest >> oracle: anOracle [
+
+	oracle := anOracle 
+]

--- a/Ume/UmeBooleanInputOracle.class.st
+++ b/Ume/UmeBooleanInputOracle.class.st
@@ -33,6 +33,6 @@ UmeBooleanInputOracle >> isAccepted: input [
 { #category : 'as yet unclassified' }
 UmeBooleanInputOracle >> problemPresence: bound [
 
-	^ bound ifFalse: [ 100 ] ifTrue: [ 0 ]
+	^ bound ifTrue: [ 100 ] ifFalse: [ 0 ]
 
 ]

--- a/Ume/UmeBooleanInputOracle.class.st
+++ b/Ume/UmeBooleanInputOracle.class.st
@@ -1,0 +1,38 @@
+Class {
+	#name : 'UmeBooleanInputOracle',
+	#superclass : 'UmeInputOracle',
+	#instVars : [
+		'block'
+	],
+	#category : 'Ume-Shrinking',
+	#package : 'Ume',
+	#tag : 'Shrinking'
+}
+
+{ #category : 'instance creation' }
+UmeBooleanInputOracle class >> from: booleanBlock [
+
+	^ self new block: booleanBlock
+
+	
+	
+]
+
+{ #category : 'accessing' }
+UmeBooleanInputOracle >> block: booleanBlock [
+
+	block := booleanBlock
+]
+
+{ #category : 'as yet unclassified' }
+UmeBooleanInputOracle >> isAccepted: input [
+	
+	^ block value: input
+]
+
+{ #category : 'as yet unclassified' }
+UmeBooleanInputOracle >> problemPresence: bound [
+
+	^ bound ifFalse: [ 100 ] ifTrue: [ 0 ]
+
+]

--- a/Ume/UmeBooleanInputOracle.class.st
+++ b/Ume/UmeBooleanInputOracle.class.st
@@ -18,16 +18,16 @@ UmeBooleanInputOracle class >> from: booleanBlock [
 	
 ]
 
+{ #category : 'as yet unclassified' }
+UmeBooleanInputOracle >> accepts: input from: _ [
+	
+	^ block value: input
+]
+
 { #category : 'accessing' }
 UmeBooleanInputOracle >> block: booleanBlock [
 
 	block := booleanBlock
-]
-
-{ #category : 'as yet unclassified' }
-UmeBooleanInputOracle >> isAccepted: input [
-	
-	^ block value: input
 ]
 
 { #category : 'as yet unclassified' }

--- a/Ume/UmeDeltaDebugger.class.st
+++ b/Ume/UmeDeltaDebugger.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : 'UmeDeltaDebugger',
 	#superclass : 'UmeShrinker',
 	#instVars : [
-		'oracle',
 		'shrinker',
 		'splittingValue'
 	],
@@ -42,18 +41,6 @@ UmeDeltaDebugger >> minimizeOne: aInput upperBound: bound [
 	].
 	^ aInput .
 
-]
-
-{ #category : 'shrinking' }
-UmeDeltaDebugger >> oracle [ 
-	
-	^ oracle 
-]
-
-{ #category : 'shrinking' }
-UmeDeltaDebugger >> oracle: anOracle [
-
-	oracle := anOracle
 ]
 
 { #category : 'private' }

--- a/Ume/UmeDeltaDebugger.class.st
+++ b/Ume/UmeDeltaDebugger.class.st
@@ -2,9 +2,7 @@ Class {
 	#name : 'UmeDeltaDebugger',
 	#superclass : 'UmeShrinker',
 	#instVars : [
-		'shrinker',
-		'splittingValue',
-		'oracle'
+		'splittingValue'
 	],
 	#category : 'Ume-Shrinking',
 	#package : 'Ume',
@@ -42,29 +40,33 @@ UmeDeltaDebugger >> initialize [
 { #category : 'shrinking' }
 UmeDeltaDebugger >> minimizeOne: aInput upperBound: bound [
 
-	| currentInput n start subsetLength someComplementFailing |
+	| currentInput granularity start subsetLength someComplementFailing |
 
 	currentInput := aInput .
-	n := 2.
+	granularity := 2.
+
 	[currentInput size >= 2 ] whileTrue: [
 		start:= 0.
-		subsetLength := currentInput size // n.
+		subsetLength := currentInput size // granularity.
 		someComplementFailing := false.
-		[ start < currentInput size ] whileTrue: [ 
-			| complement |
+		[ start < currentInput size ] whileTrue: [ | complement |
+			self minimizationDone.
 			complement := self getComplement: currentInput start: start length: subsetLength .
 			(self triggerBug: complement upperBound: bound ) ifTrue: [ 
 				currentInput := complement.
-				n := (n -1) max: 2.
+				granularity := (granularity -1) max: 2.
 				someComplementFailing := true.
 				start := currentInput size.
-			] ifFalse: [ 
-			start := start+ subsetLength. ]].
+			] ifFalse: [
+				self failedMinimization.
+				start := start + subsetLength
+			]
+		].
 		
 		someComplementFailing ifFalse: [ 
-			(n = currentInput size) ifTrue:[
+			(granularity = currentInput size) ifTrue:[
 				^ currentInput ].
-			n := (n*2) min: currentInput size.
+			granularity := (granularity*2) min: currentInput size.
 		 ]
 	].
 

--- a/Ume/UmeDeltaDebugger.class.st
+++ b/Ume/UmeDeltaDebugger.class.st
@@ -19,7 +19,7 @@ UmeDeltaDebugger >> asInput: aString [
 { #category : 'shrinking' }
 UmeDeltaDebugger >> evalInput: input [
 
-	^ ( oracle value: input )
+	^ ( oracle isAccepted: input )
 ]
 
 { #category : 'testing' }
@@ -46,12 +46,6 @@ UmeDeltaDebugger >> minimizeOne: stringInput upperBound: bound [
 
 	^ stringInput
 
-]
-
-{ #category : 'shrinking' }
-UmeDeltaDebugger >> problemPresence: bound [ 
-	
-	^ bound ifFalse: [ 100 ] ifTrue: [ 0 ]
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeDeltaDebugger.class.st
+++ b/Ume/UmeDeltaDebugger.class.st
@@ -84,6 +84,6 @@ UmeDeltaDebugger >> tree: aString [
 { #category : 'testing' }
 UmeDeltaDebugger >> triggerBug: input upperBound: _ [
 	
-	^ self evalInput: input
+	^ oracle accepts: input from: _ 
 
 ]

--- a/Ume/UmeDeltaDebugger.class.st
+++ b/Ume/UmeDeltaDebugger.class.st
@@ -30,16 +30,34 @@ UmeDeltaDebugger >> initialize [
 ]
 
 { #category : 'shrinking' }
-UmeDeltaDebugger >> minimizeOne: aInput upperBound: bound [
+UmeDeltaDebugger >> minimizeOne: stringInput upperBound: bound [
+	
 	| inputSlice|
 	
-	(0 < aInput size and: splittingValue <= aInput size) ifTrue: [ 
-		inputSlice := self split: aInput into: splittingValue. 
+	(0 < stringInput size and: splittingValue <= stringInput size) ifTrue: [ 
+		inputSlice := self split: stringInput into: splittingValue. 
 		inputSlice do: [ :aSubInput |
-			(self triggerBug: aSubInput upperBound:bound ) ifTrue: [ 
-				^ aSubInput]].
+			self minimizationDone.
+			(self triggerBug: aSubInput upperBound: bound)
+				ifTrue: [ ^ aSubInput ]
+				ifFalse: [ self failedMinimization ]
+		].
 	].
-	^ aInput .
+
+	^ stringInput
+
+]
+
+{ #category : 'shrinking' }
+UmeDeltaDebugger >> problemPresence: bound [ 
+	
+	^ bound ifFalse: [ 100 ] ifTrue: [ 0 ]
+]
+
+{ #category : 'shrinking' }
+UmeDeltaDebugger >> sizeOf: string [
+
+	^ string size
 
 ]
 

--- a/Ume/UmeDeltaDebugger.class.st
+++ b/Ume/UmeDeltaDebugger.class.st
@@ -15,12 +15,6 @@ UmeDeltaDebugger >> asInput: aString [
 	^ aString
 ]
 
-{ #category : 'shrinking' }
-UmeDeltaDebugger >> evalInput: input [
-
-	^ ( oracle isAccepted: input )
-]
-
 { #category : 'testing' }
 UmeDeltaDebugger >> getComplement: input start: start length: subsetLength [
 
@@ -88,9 +82,8 @@ UmeDeltaDebugger >> tree: aString [
 ]
 
 { #category : 'testing' }
-UmeDeltaDebugger >> triggerBug: string upperBound: _ [
+UmeDeltaDebugger >> triggerBug: input upperBound: _ [
 	
-	^ (self evalInput: string) not
-	
+	^ self evalInput: input
 
 ]

--- a/Ume/UmeFeedbackTableOracle.class.st
+++ b/Ume/UmeFeedbackTableOracle.class.st
@@ -1,0 +1,98 @@
+Class {
+	#name : 'UmeFeedbackTableOracle',
+	#superclass : 'UmeInputOracle',
+	#instVars : [
+		'threshold',
+		'programBlock',
+		'classesToProfile',
+		'feedbackEvaluator',
+		'evaluator',
+		'memo'
+	],
+	#category : 'Ume-Shrinking',
+	#package : 'Ume',
+	#tag : 'Shrinking'
+}
+
+{ #category : 'testing' }
+UmeFeedbackTableOracle >> classesToProfile [
+
+	^ classesToProfile 
+]
+
+{ #category : 'testing' }
+UmeFeedbackTableOracle >> classesToProfile: someClassesToProfile [
+
+	classesToProfile := someClassesToProfile 
+]
+
+{ #category : 'shrinking' }
+UmeFeedbackTableOracle >> evalInput: input [
+
+	| profilingResult umeCase program |
+	
+	memo at: input ifAbsentPut: [
+		program := PBAProgram from: [ programBlock value: input ] forClasses: classesToProfile.
+
+		[ 	profilingResult := evaluator analyzer analyze: program.
+			umeCase := UmeTest new result: (UmeEvalSuccess new profilingResult: profilingResult)
+		] on: Error do: [ ^ nil ].
+
+		(feedbackEvaluator eval: umeCase) absoluteImprovement
+	].
+	
+	^ memo at: input
+]
+
+{ #category : 'accessing' }
+UmeFeedbackTableOracle >> evaluator [
+	
+	^ evaluator
+]
+
+{ #category : 'accessing' }
+UmeFeedbackTableOracle >> evaluator: anEvaluator [
+
+	evaluator := anEvaluator
+]
+
+{ #category : 'shrinking' }
+UmeFeedbackTableOracle >> feedbackEvaluator [
+
+	^ feedbackEvaluator 
+]
+
+{ #category : 'shrinking' }
+UmeFeedbackTableOracle >> feedbackEvaluator: aFeedbackEvaluator [
+
+	feedbackEvaluator := aFeedbackEvaluator 
+]
+
+{ #category : 'accessing' }
+UmeFeedbackTableOracle >> initialize [
+
+	super initialize.
+	threshold := 0.95.
+	programBlock := nil.
+	classesToProfile := nil.
+	feedbackEvaluator := nil.
+	memo := Dictionary new.
+]
+
+{ #category : 'shrinking' }
+UmeFeedbackTableOracle >> resetMemoization [
+
+	memo := Dictionary new.
+]
+
+{ #category : 'accessing' }
+UmeFeedbackTableOracle >> threshold [
+
+	^ threshold
+]
+
+{ #category : 'accessing' }
+UmeFeedbackTableOracle >> threshold: aThreshold [
+
+	threshold := aThreshold
+]

--- a/Ume/UmeGRABRShrinker.class.st
+++ b/Ume/UmeGRABRShrinker.class.st
@@ -2,8 +2,6 @@ Class {
 	#name : 'UmeGRABRShrinker',
 	#superclass : 'UmeShrinker',
 	#instVars : [
-		'grammar',
-		'oracle',
 		'reductionStrategy'
 	],
 	#category : 'Ume-Shrinking',
@@ -36,12 +34,6 @@ UmeGRABRShrinker >> evalInput: input [
 ]
 
 { #category : 'shrinking' }
-UmeGRABRShrinker >> grammar: aGrammar [
-
-	grammar := aGrammar
-]
-
-{ #category : 'shrinking' }
 UmeGRABRShrinker >> minimizeOne: originalTree upperBound: bound [
 
 	| reducedTree |
@@ -58,18 +50,6 @@ UmeGRABRShrinker >> minimizeOne: originalTree upperBound: bound [
 		1 halt.]."
 	
 	^ reducedTree 
-]
-
-{ #category : 'shrinking' }
-UmeGRABRShrinker >> oracle [
-
-	^ oracle
-]
-
-{ #category : 'shrinking' }
-UmeGRABRShrinker >> oracle: aOracle [
-
-	oracle := aOracle
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeGRABRShrinker.class.st
+++ b/Ume/UmeGRABRShrinker.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'UmeGRABRShrinker',
-	#superclass : 'UmeShrinker',
+	#superclass : 'UmeGrammarShrinker',
 	#instVars : [
 		'reductionStrategy',
 		'seen'
@@ -21,6 +21,7 @@ UmeGRABRShrinker >> candidates: subTree matching: symbol [
 
 	| allCandidates |
 	
+	"TODO: Improve performance here"
 	allCandidates := (reductionStrategy reduce: subTree using: grammar matching: symbol) asSet.
 
 	^ allCandidates difference: seen
@@ -69,12 +70,6 @@ UmeGRABRShrinker >> minimizeOne: originalTree upperBound: bound [
 	^ originalTree
 ]
 
-{ #category : 'shrinking' }
-UmeGRABRShrinker >> parse: input [
-
-	^ UmeGrammarParser parse: input from: grammar
-]
-
 { #category : 'accessing' }
 UmeGRABRShrinker >> reductionStrategy [
 
@@ -99,12 +94,6 @@ UmeGRABRShrinker >> replaceSubtreeIn: tree by: subtree index: index [
 	replacementTree children: test.
 	
 	^ treeCopy 
-]
-
-{ #category : 'shrinking' }
-UmeGRABRShrinker >> tree: input [
-
-	^ self parse: input
 ]
 
 { #category : 'testing' }

--- a/Ume/UmeGRABRShrinker.class.st
+++ b/Ume/UmeGRABRShrinker.class.st
@@ -47,7 +47,8 @@ UmeGRABRShrinker >> evalInput: input [
 UmeGRABRShrinker >> initialize [ 
 
 	super initialize.
-	seen := Set new. 
+	seen := Set new.
+	reductionStrategy := UmeSimplifyGrammarBoth.
 	
 ]
 

--- a/Ume/UmeGRABRShrinker.class.st
+++ b/Ume/UmeGRABRShrinker.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : 'UmeShrinker',
 	#instVars : [
 		'reductionStrategy',
-    'seen'
+		'seen'
 	],
 	#category : 'Ume-Shrinking',
 	#package : 'Ume',
@@ -40,7 +40,7 @@ UmeGRABRShrinker >> copyTree: tree [
 { #category : 'shrinking' }
 UmeGRABRShrinker >> evalInput: input [
 
-	^ ( oracle value: input )
+	^ ( oracle isAccepted: input )
 ]
 
 { #category : 'shrinking' }
@@ -56,15 +56,19 @@ UmeGRABRShrinker >> minimizeOne: originalTree upperBound: bound [
 
 	originalTree allNodes doWithIndex: [ :subTree :index | 
 		( subTree isLeaf ) ifFalse: [ | symbol |
-		symbol := subTree tag. 
-		( self candidates: subTree matching: symbol ) do: [ :candidate |
-			seen add: candidate. 
-			( candidate treeSize < originalTree treeSize) ifTrue: [ | newTree |
-				newTree := self replaceSubtreeIn: originalTree by: candidate index: index.
-				(self triggerBug: newTree upperBound: bound ) ifTrue: [ ^ newTree ] ]
-				] 
+			symbol := subTree tag. 
+			( self candidates: subTree matching: symbol ) do: [ :candidate |
+				seen add: candidate. 
+				( candidate treeSize < originalTree treeSize) ifTrue: [ | newTree |
+					newTree := self replaceSubtreeIn: originalTree by: candidate index: index.
+					self minimizationDone.
+					(self triggerBug: newTree upperBound: bound ) ifTrue: [
+						^ newTree
+					] ifFalse: [ self failedMinimization. ]
+				]
 			] 
-		].
+		] 
+	].
 	
 	^ originalTree
 ]

--- a/Ume/UmeGRABRShrinker.class.st
+++ b/Ume/UmeGRABRShrinker.class.st
@@ -38,12 +38,6 @@ UmeGRABRShrinker >> copyTree: tree [
 ]
 
 { #category : 'shrinking' }
-UmeGRABRShrinker >> evalInput: input [
-
-	^ ( oracle isAccepted: input )
-]
-
-{ #category : 'shrinking' }
 UmeGRABRShrinker >> initialize [ 
 
 	super initialize.
@@ -118,7 +112,7 @@ UmeGRABRShrinker >> triggerBug: aTree upperBound: _ [
 	|input|
 	
 	input := (self asInput: aTree).
-	(self checkGrammar: input ) ifFalse: [ ^false ].
+	(self checkGrammar: input ) ifFalse: [ ^ false ].
 
-	^ (self evalInput: input ) not
+	^ self evalInput: input
 ]

--- a/Ume/UmeGRABRShrinker.class.st
+++ b/Ume/UmeGRABRShrinker.class.st
@@ -22,6 +22,7 @@ UmeGRABRShrinker >> candidates: subTree matching: symbol [
 	| allCandidates |
 	
 	allCandidates := (reductionStrategy reduce: subTree using: grammar matching: symbol) asSet.
+
 	^ allCandidates difference: seen
 ]
 
@@ -114,5 +115,5 @@ UmeGRABRShrinker >> triggerBug: aTree upperBound: _ [
 	input := (self asInput: aTree).
 	(self checkGrammar: input ) ifFalse: [ ^ false ].
 
-	^ self evalInput: input
+	^ oracle accepts: input from: _ 
 ]

--- a/Ume/UmeGrammarBasedShrinker.class.st
+++ b/Ume/UmeGrammarBasedShrinker.class.st
@@ -4,7 +4,6 @@ Class {
 	#instVars : [
 		'evaluator',
 		'feedbackEvaluator',
-		'threshold',
 		'programBlock',
 		'classesToProfile',
 		'memo'
@@ -94,11 +93,10 @@ UmeGrammarBasedShrinker >> feedbackEvaluator: aFeedbackEvaluator [
 UmeGrammarBasedShrinker >> initialize [ 
 	
 	super initialize.
-	threshold := 0.95.
+"	threshold := 0.95."
 	programBlock := nil.
 	classesToProfile := nil.
 	feedbackEvaluator := nil.
-	grammar := nil.
 	memo := Dictionary new.
 ]
 
@@ -165,18 +163,6 @@ UmeGrammarBasedShrinker >> resetMemoization [
 	memo := Dictionary new.
 ]
 
-{ #category : 'testing' }
-UmeGrammarBasedShrinker >> threshold [
-
-	^ threshold 
-]
-
-{ #category : 'testing' }
-UmeGrammarBasedShrinker >> threshold: aThreshold [
-
-	threshold := aThreshold.
-]
-
 { #category : 'shrinking' }
 UmeGrammarBasedShrinker >> tree: input [
 
@@ -186,7 +172,9 @@ UmeGrammarBasedShrinker >> tree: input [
 { #category : 'testing' }
 UmeGrammarBasedShrinker >> triggerBug: score upperBound: originalScore [
 
-	score ifNil: [ ^ false ].
+"	score ifNil: [ ^ false ].
 
-	^ score >= (originalScore * threshold)
+	^ score >= (originalScore * threshold)"
+
+	^ oracle accepts: score from: originalScore
 ]

--- a/Ume/UmeGrammarBasedShrinker.class.st
+++ b/Ume/UmeGrammarBasedShrinker.class.st
@@ -1,13 +1,6 @@
 Class {
 	#name : 'UmeGrammarBasedShrinker',
-	#superclass : 'UmeShrinker',
-	#instVars : [
-		'evaluator',
-		'feedbackEvaluator',
-		'programBlock',
-		'classesToProfile',
-		'memo'
-	],
+	#superclass : 'UmeGrammarShrinker',
 	#category : 'Ume-Shrinking',
 	#package : 'Ume',
 	#tag : 'Shrinking'
@@ -36,71 +29,6 @@ UmeGrammarBasedShrinker >> candidates: root [
 ]
 
 { #category : 'testing' }
-UmeGrammarBasedShrinker >> classesToProfile [
-
-	^ classesToProfile 
-]
-
-{ #category : 'testing' }
-UmeGrammarBasedShrinker >> classesToProfile: someClassesToProfile [
-
-	classesToProfile := someClassesToProfile 
-]
-
-{ #category : 'shrinking' }
-UmeGrammarBasedShrinker >> evalInput: input [
-
-	| profilingResult umeCase program |
-	
-	memo at: input ifAbsentPut: [
-		program := PBAProgram from: [ programBlock value: input ] forClasses: classesToProfile.
-
-		[ 	profilingResult := evaluator analyzer analyze: program.
-			umeCase := UmeTest new result: (UmeEvalSuccess new profilingResult: profilingResult)
-		] on: Error do: [ ^ nil ].
-
-		(feedbackEvaluator eval: umeCase) absoluteImprovement
-	].
-	
-	^ memo at: input
-]
-
-{ #category : 'accessing' }
-UmeGrammarBasedShrinker >> evaluator [
-	
-	^ evaluator
-]
-
-{ #category : 'accessing' }
-UmeGrammarBasedShrinker >> evaluator: anEvaluator [
-
-	evaluator := anEvaluator
-]
-
-{ #category : 'shrinking' }
-UmeGrammarBasedShrinker >> feedbackEvaluator [
-
-	^ feedbackEvaluator 
-]
-
-{ #category : 'shrinking' }
-UmeGrammarBasedShrinker >> feedbackEvaluator: aFeedbackEvaluator [
-
-	feedbackEvaluator := aFeedbackEvaluator 
-]
-
-{ #category : 'testing' }
-UmeGrammarBasedShrinker >> initialize [ 
-	
-	super initialize.
-"	threshold := 0.95."
-	programBlock := nil.
-	classesToProfile := nil.
-	feedbackEvaluator := nil.
-	memo := Dictionary new.
-]
-
-{ #category : 'testing' }
 UmeGrammarBasedShrinker >> isValidTree: node [
 
 	| input derivation |
@@ -126,12 +54,14 @@ UmeGrammarBasedShrinker >> minimizeOne: tree upperBound: upperBound [
 			seen add: candidate.
 			parent := candidate parent.
 			(parent notNil and: [ allNodes includes: candidate ]) ifTrue: [ | index |
-				"TODO: add a memoization to know if the candidate is removable or not"
 				index := parent children indexOf: candidate.
 				parent replaceChildAt: index with: candidate emptyTree.
-				
+				self minimizationDone.
 				trigger := self triggerBug: (self evalInput: tree asInput) upperBound: upperBound.
-				((self isValidTree: tree) and: [ trigger ]) ifFalse: [ parent replaceChildAt: index with: candidate ]
+				((self isValidTree: tree) and: [ trigger ]) ifFalse: [
+					self failedMinimization.
+					parent replaceChildAt: index with: candidate
+				]
 		 	]
 		]
 	].
@@ -140,41 +70,11 @@ UmeGrammarBasedShrinker >> minimizeOne: tree upperBound: upperBound [
 ]
 
 { #category : 'testing' }
-UmeGrammarBasedShrinker >> parse: input [
-
-	^ UmeGrammarParser parse: input from: grammar
-]
-
-{ #category : 'testing' }
-UmeGrammarBasedShrinker >> programBlock [
-
-	^ programBlock 
-]
-
-{ #category : 'testing' }
-UmeGrammarBasedShrinker >> programBlock: aProgramBlock [
-
-	programBlock := aProgramBlock 
-]
-
-{ #category : 'shrinking' }
-UmeGrammarBasedShrinker >> resetMemoization [
-
-	memo := Dictionary new.
-]
-
-{ #category : 'shrinking' }
-UmeGrammarBasedShrinker >> tree: input [
-
-	^ self parse: input
-]
-
-{ #category : 'testing' }
-UmeGrammarBasedShrinker >> triggerBug: score upperBound: originalScore [
+UmeGrammarBasedShrinker >> triggerBug: evalResult upperBound: originalScore [
 
 "	score ifNil: [ ^ false ].
 
 	^ score >= (originalScore * threshold)"
 
-	^ oracle accepts: score from: originalScore
+	^ oracle accepts: evalResult from: originalScore
 ]

--- a/Ume/UmeGrammarBasedShrinker.class.st
+++ b/Ume/UmeGrammarBasedShrinker.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : 'UmeGrammarBasedShrinker',
 	#superclass : 'UmeShrinker',
 	#instVars : [
-		'grammar',
 		'evaluator',
 		'feedbackEvaluator',
 		'threshold',
@@ -89,12 +88,6 @@ UmeGrammarBasedShrinker >> feedbackEvaluator [
 UmeGrammarBasedShrinker >> feedbackEvaluator: aFeedbackEvaluator [
 
 	feedbackEvaluator := aFeedbackEvaluator 
-]
-
-{ #category : 'accessing' }
-UmeGrammarBasedShrinker >> grammar: aGrammar [
-
-	grammar := aGrammar 
 ]
 
 { #category : 'testing' }

--- a/Ume/UmeGrammarShrinker.class.st
+++ b/Ume/UmeGrammarShrinker.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'UmeGrammarShrinker',
+	#superclass : 'UmeShrinker',
+	#category : 'Ume-Shrinking',
+	#package : 'Ume',
+	#tag : 'Shrinking'
+}
+
+{ #category : 'testing' }
+UmeGrammarShrinker >> parse: input [
+
+	^ UmeGrammarParser parse: input from: grammar
+]
+
+{ #category : 'shrinking' }
+UmeGrammarShrinker >> tree: input [
+
+	^ self parse: input
+]

--- a/Ume/UmeInputOracle.class.st
+++ b/Ume/UmeInputOracle.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'UmeInputOracle',
+	#superclass : 'Object',
+	#category : 'Ume-Shrinking',
+	#package : 'Ume',
+	#tag : 'Shrinking'
+}
+
+{ #category : 'as yet unclassified' }
+UmeInputOracle >> isAccepted: input [
+	
+	self subclassResponsibility 
+]
+
+{ #category : 'as yet unclassified' }
+UmeInputOracle >> problemPresence: bound [
+
+	self subclassResponsibility 
+]

--- a/Ume/UmeInputOracle.class.st
+++ b/Ume/UmeInputOracle.class.st
@@ -7,7 +7,8 @@ Class {
 }
 
 { #category : 'as yet unclassified' }
-UmeInputOracle >> isAccepted: input [
+UmeInputOracle >> accepts: bound from: base [
+
 	"It returns true if the input triggers the bug"
 	self subclassResponsibility 
 ]

--- a/Ume/UmeInputOracle.class.st
+++ b/Ume/UmeInputOracle.class.st
@@ -8,7 +8,7 @@ Class {
 
 { #category : 'as yet unclassified' }
 UmeInputOracle >> isAccepted: input [
-	
+	"It returns true if the input triggers the bug"
 	self subclassResponsibility 
 ]
 

--- a/Ume/UmeReductionShrinkerTest.class.st
+++ b/Ume/UmeReductionShrinkerTest.class.st
@@ -5,3 +5,9 @@ Class {
 	#package : 'Ume',
 	#tag : 'Shrinking'
 }
+
+{ #category : 'as yet unclassified' }
+UmeReductionShrinkerTest >> oracleByBlock: block [
+
+	^ UmeBooleanInputOracle from: block
+]

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -23,7 +23,7 @@ UmeShrinker >> asInput: tree [
 UmeShrinker >> evalInput: input [
 
 	"Returns true if the input triggers the bug, otherwise, it returns false"
-	^ oracle isAccepted: input
+	^ oracle accepts: input from: nil
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -81,7 +81,6 @@ UmeShrinker >> minimizeTree: tree upperBound: bound [
 	maxIterations timesRepeat: [ | minimized |
 		minimized := self minimizeOne: currentTree upperBound: bound.
 		(minimized = currentTree) ifTrue: [ ^ currentTree ].
-		self minimizationDone.
 		currentTree := minimized.
 	].
 
@@ -104,16 +103,27 @@ UmeShrinker >> oracle: anOracle [
 UmeShrinker >> percentageInputReduced: tree given: minimizedTree [
 
 	| initialNumOfNodes currentNumOfNodes |
-	initialNumOfNodes := tree allNodes size.
-	currentNumOfNodes := minimizedTree allNodes size.
+	initialNumOfNodes := self sizeOf: tree.
+	currentNumOfNodes := self sizeOf: minimizedTree.
 
-	^ 100 - ((currentNumOfNodes * 100) / initialNumOfNodes)
+	^ (100 - ((currentNumOfNodes * 100) / initialNumOfNodes)) asFloat
 ]
 
 { #category : 'shrinking' }
-UmeShrinker >> percentageProblemPreservation: upperBound given: currentValue [
+UmeShrinker >> percentageProblemPreservation: upperBound given: currentBound [
 
-	1 halt.
+	| baseline current |
+	
+	baseline := self problemPresence: upperBound.
+	current := self problemPresence: currentBound.
+	
+	^ ((current * 100) / baseline) asFloat
+]
+
+{ #category : 'shrinking' }
+UmeShrinker >> problemPresence: bound [
+
+	self subclassResponsibility 
 ]
 
 { #category : 'shrinking' }
@@ -121,22 +131,22 @@ UmeShrinker >> profiledShrink: input [
 
 	| tree minimizedTree upperBound initialTime totalTime minimizedInput |
 	
-	initialTime := Time millisecondClockValue.
+	initialTime := Time microsecondClockValue.
 	(self tree: input) ifNil: [ Error signal: 'Trying to reduce a non valid input' ].
 	upperBound := self evalInput: input.
 
 	tree := self tree: input.
 	
 	minimizedTree := self minimizeTree: tree upperBound: upperBound.	
-	totalTime := Time millisecondClockValue - initialTime.
+	totalTime := Time microsecondClockValue - initialTime.
 	minimizedInput := self asInput: minimizedTree.
 	
 	^ {
-		'totalTime' -> totalTime.
+		'totalTime' -> (Duration microSeconds: totalTime).
 		'neededReductions' -> reductionsDone.
 		'failedReductions' -> failedReductionsDone.
-		'%problemPreservation' -> self percentageProblemPreservation: upperBound given: (self evalInput: minimizedInput).
-		'%inputReduction' -> self percentageInputReduced: tree given: minimizedTree.
+		'%problemPreservation' -> (self percentageProblemPreservation: upperBound given: (self evalInput: minimizedInput)).
+		'%inputReduction' -> (self percentageInputReduced: tree given: minimizedTree).
 		'minimizedInput' -> minimizedInput
 	}
 ]
@@ -153,6 +163,12 @@ UmeShrinker >> shrink: input [
 	minimizedTree := self minimizeTree: tree upperBound: upperBound.
 
 	^ self asInput: minimizedTree
+]
+
+{ #category : 'shrinking' }
+UmeShrinker >> sizeOf: tree [
+
+	^ tree allNodes size
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -4,7 +4,9 @@ Class {
 	#instVars : [
 		'maxIterations',
 		'reductionsDone',
-		'failedReductionsDone'
+		'failedReductionsDone',
+		'oracle',
+		'grammar'
 	],
 	#category : 'Ume-Shrinking',
 	#package : 'Ume',
@@ -23,6 +25,24 @@ UmeShrinker >> evalInput: input [
 	self subclassResponsibility 
 ]
 
+{ #category : 'shrinking' }
+UmeShrinker >> failedMinimization [
+
+	failedReductionsDone := failedReductionsDone + 1
+]
+
+{ #category : 'shrinking' }
+UmeShrinker >> grammar [
+	
+	^ grammar
+]
+
+{ #category : 'shrinking' }
+UmeShrinker >> grammar: aGrammar [
+
+	grammar := aGrammar
+]
+
 { #category : 'testing' }
 UmeShrinker >> initialize [ 
 	
@@ -33,9 +53,19 @@ UmeShrinker >> initialize [
 ]
 
 { #category : 'shrinking' }
+UmeShrinker >> minimizationDone [
+
+	reductionsDone := reductionsDone + 1
+]
+
+{ #category : 'shrinking' }
 UmeShrinker >> minimizeOne: tree upperBound: bound [
 
-	self subclassResponsibility 
+	"Each sublclass must call:
+		self minimizationDone -> each time it proceeds to do a reduction ( failed or not )
+		self failedMinimization -> each time it proceeds to do a failed reduction
+	"
+	self subclassResponsibility
 ]
 
 { #category : 'shrinking' }
@@ -48,10 +78,23 @@ UmeShrinker >> minimizeTree: tree upperBound: bound [
 	maxIterations timesRepeat: [ | minimized |
 		minimized := self minimizeOne: currentTree upperBound: bound.
 		(minimized = currentTree) ifTrue: [ ^ currentTree ].
+		self minimizationDone.
 		currentTree := minimized.
 	].
 
 	^ currentTree
+]
+
+{ #category : 'shrinking' }
+UmeShrinker >> oracle [ 
+	
+	^ oracle 
+]
+
+{ #category : 'shrinking' }
+UmeShrinker >> oracle: anOracle [
+
+	oracle := anOracle
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -2,7 +2,9 @@ Class {
 	#name : 'UmeShrinker',
 	#superclass : 'Object',
 	#instVars : [
-		'maxIterations'
+		'maxIterations',
+		'reductionsDone',
+		'failedReductionsDone'
 	],
 	#category : 'Ume-Shrinking',
 	#package : 'Ume',
@@ -26,6 +28,8 @@ UmeShrinker >> initialize [
 	
 	super initialize.
 	maxIterations := 1000.
+	reductionsDone := 0.
+	failedReductionsDone := 0.
 ]
 
 { #category : 'shrinking' }
@@ -48,6 +52,47 @@ UmeShrinker >> minimizeTree: tree upperBound: bound [
 	].
 
 	^ currentTree
+]
+
+{ #category : 'shrinking' }
+UmeShrinker >> percentageInputReduced: tree given: minimizedTree [
+
+	| initialNumOfNodes currentNumOfNodes |
+	initialNumOfNodes := tree allNodes size.
+	currentNumOfNodes := minimizedTree allNodes size.
+
+	^ 100 - ((currentNumOfNodes * 100) / initialNumOfNodes)
+]
+
+{ #category : 'shrinking' }
+UmeShrinker >> percentageProblemPreservation: upperBound given: currentValue [
+
+	1 halt.
+]
+
+{ #category : 'shrinking' }
+UmeShrinker >> profiledShrink: input [
+
+	| tree minimizedTree upperBound initialTime totalTime minimizedInput |
+	
+	initialTime := Time millisecondClockValue.
+	(self tree: input) ifNil: [ Error signal: 'Trying to reduce a non valid input' ].
+	upperBound := self evalInput: input.
+
+	tree := self tree: input.
+	
+	minimizedTree := self minimizeTree: tree upperBound: upperBound.	
+	totalTime := Time millisecondClockValue - initialTime.
+	minimizedInput := self asInput: minimizedTree.
+	
+	^ {
+		'totalTime' -> totalTime.
+		'neededReductions' -> reductionsDone.
+		'failedReductions' -> failedReductionsDone.
+		'%problemPreservation' -> self percentageProblemPreservation: upperBound given: (self evalInput: minimizedInput).
+		'%inputReduction' -> self percentageInputReduced: tree given: minimizedTree.
+		'minimizedInput' -> minimizedInput
+	}
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -117,6 +117,8 @@ UmeShrinker >> percentageProblemPreservation: upperBound given: currentBound [
 	baseline := oracle problemPresence: upperBound.
 	current := oracle problemPresence: currentBound.
 	
+	(baseline = 0) ifTrue: [ ^ 0 ].
+	
 	^ ((current * 100) / baseline) asFloat
 ]
 
@@ -137,12 +139,12 @@ UmeShrinker >> profiledShrink: input [
 	
 	^ {
 		'totalTime' -> (Duration microSeconds: totalTime).
-		'neededReductions' -> reductionsDone.
-		'failedReductions' -> failedReductionsDone.
+		'neededReductions' -> reductionsDone asFloat.
+		'failedReductions' -> failedReductionsDone asFloat.
 		'%problemPreservation' -> (self percentageProblemPreservation: upperBound given: (self evalInput: minimizedInput)).
 		'%inputReduction' -> (self percentageInputReduced: tree given: minimizedTree).
 		'minimizedInput' -> minimizedInput
-	}
+	} asDictionary
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -73,6 +73,9 @@ UmeShrinker >> minimizeTree: tree upperBound: bound [
 
 	| currentTree |
 	
+	reductionsDone := 0.
+	failedReductionsDone := 0.
+
 	"This minimize as much as possible the input".
 	currentTree := tree copy.
 	maxIterations timesRepeat: [ | minimized |

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -22,7 +22,8 @@ UmeShrinker >> asInput: tree [
 { #category : 'shrinking' }
 UmeShrinker >> evalInput: input [
 
-	self subclassResponsibility 
+	"Returns true if the input triggers the bug, otherwise, it returns false"
+	^ oracle isAccepted: input
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -137,7 +137,7 @@ UmeShrinker >> profiledShrink: input [
 	minimizedTree := self minimizeTree: tree upperBound: upperBound.	
 	totalTime := Time microsecondClockValue - initialTime.
 	minimizedInput := self asInput: minimizedTree.
-	
+1 halt.
 	^ {
 		'totalTime' -> (Duration microSeconds: totalTime).
 		'neededReductions' -> reductionsDone asFloat.

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -137,7 +137,7 @@ UmeShrinker >> profiledShrink: input [
 	minimizedTree := self minimizeTree: tree upperBound: upperBound.	
 	totalTime := Time microsecondClockValue - initialTime.
 	minimizedInput := self asInput: minimizedTree.
-1 halt.
+
 	^ {
 		'totalTime' -> (Duration microSeconds: totalTime).
 		'neededReductions' -> reductionsDone asFloat.

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -114,16 +114,10 @@ UmeShrinker >> percentageProblemPreservation: upperBound given: currentBound [
 
 	| baseline current |
 	
-	baseline := self problemPresence: upperBound.
-	current := self problemPresence: currentBound.
+	baseline := oracle problemPresence: upperBound.
+	current := oracle problemPresence: currentBound.
 	
 	^ ((current * 100) / baseline) asFloat
-]
-
-{ #category : 'shrinking' }
-UmeShrinker >> problemPresence: bound [
-
-	self subclassResponsibility 
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeShrinkingAExprBenchmark.class.st
+++ b/Ume/UmeShrinkingAExprBenchmark.class.st
@@ -7,12 +7,14 @@ Class {
 }
 
 { #category : 'initialization' }
-UmeShrinkingAExprBenchmark >> initialize [ 
+UmeShrinkingAExprBenchmark >> initialize [
 
 	super initialize.
 	grammar := AritExpressionGrammar new.
 	tests := {
-		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
+		ShrinkerTest input: '1+(2*3)/0' oracle: DivideZeroOracle new.
+	}
+	"ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
 		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includes: $1) not]).
 		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
 		ShrinkerTest input: '2*3' oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
@@ -20,8 +22,7 @@ UmeShrinkingAExprBenchmark >> initialize [
 		ShrinkerTest input: '3' oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
 		ShrinkerTest input: '1+(3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(' ) not]).
 		ShrinkerTest input: '1+(3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '4' ) not]).
-		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '2' ) not]).
-	}.
+		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '2' ) not])."
 ]
 
 { #category : 'initialization' }

--- a/Ume/UmeShrinkingAExprBenchmark.class.st
+++ b/Ume/UmeShrinkingAExprBenchmark.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : 'UmeShrinkingAExprBenchmark',
+	#superclass : 'UmeShrinkingBenchmark',
+	#category : 'Ume-Shrinking',
+	#package : 'Ume',
+	#tag : 'Shrinking'
+}
+
+{ #category : 'initialization' }
+UmeShrinkingAExprBenchmark >> initialize [ 
+
+	super initialize.
+	grammar := AritExpressionGrammar new.
+	tests := {
+		ShrinkerTest new: 'input' error: 'error?'
+	}.
+]

--- a/Ume/UmeShrinkingAExprBenchmark.class.st
+++ b/Ume/UmeShrinkingAExprBenchmark.class.st
@@ -12,6 +12,6 @@ UmeShrinkingAExprBenchmark >> initialize [
 	super initialize.
 	grammar := AritExpressionGrammar new.
 	tests := {
-		ShrinkerTest new: 'input' error: 'error?'
+		ShrinkerTest input: 'input' oracle: ''
 	}.
 ]

--- a/Ume/UmeShrinkingAExprBenchmark.class.st
+++ b/Ume/UmeShrinkingAExprBenchmark.class.st
@@ -13,6 +13,7 @@ UmeShrinkingAExprBenchmark >> initialize [
 	grammar := AritExpressionGrammar new.
 	tests := {
 		ShrinkerTest input: '1+(2*3)/0' oracle: DivideZeroOracle new.
+		ShrinkerTest input: '((8500/(208000*80))+(165468468)*(423-12)*(999/(12+88)))/(((145*4)-580)*3)+((456)*12)-(89/(45+(12*8)))+(77*14)' oracle: DivideZeroOracle new.
 	}
 	"ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
 		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includes: $1) not]).

--- a/Ume/UmeShrinkingAExprBenchmark.class.st
+++ b/Ume/UmeShrinkingAExprBenchmark.class.st
@@ -12,6 +12,20 @@ UmeShrinkingAExprBenchmark >> initialize [
 	super initialize.
 	grammar := AritExpressionGrammar new.
 	tests := {
-		ShrinkerTest input: 'input' oracle: ''
+		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
+		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includes: $1) not]).
+		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
+		ShrinkerTest input: '2*3' oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
+		ShrinkerTest input: '3*2' oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
+		ShrinkerTest input: '3' oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
+		ShrinkerTest input: '1+(3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(' ) not]).
+		ShrinkerTest input: '1+(3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '4' ) not]).
+		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '2' ) not]).
 	}.
+]
+
+{ #category : 'initialization' }
+UmeShrinkingAExprBenchmark >> oracleByBlock: block [
+
+	^ UmeBooleanInputOracle from: block
 ]

--- a/Ume/UmeShrinkingAExprBenchmark.class.st
+++ b/Ume/UmeShrinkingAExprBenchmark.class.st
@@ -13,7 +13,7 @@ UmeShrinkingAExprBenchmark >> initialize [
 	grammar := AritExpressionGrammar new.
 	tests := {
 		ShrinkerTest input: '1+(2*3)/0' oracle: DivideZeroOracle new.
-		ShrinkerTest input: '((8500/(208000*80))+(165468468)*(423-12)*(999/(12+88)))/(((145*4)-580)*3)+((456)*12)-(89/(45+(12*8)))+(77*14)' oracle: DivideZeroOracle new.
+		"ShrinkerTest input: '((8500/(208000*80))+(165468468)*(423-12)*(999/(12+88)))/(((145*4)-580)*3)+((456)*12)-(89/(45+(12*8)))+(77*14)' oracle: DivideZeroOracle new."
 	}
 	"ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
 		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includes: $1) not]).

--- a/Ume/UmeShrinkingAExprBenchmark.class.st
+++ b/Ume/UmeShrinkingAExprBenchmark.class.st
@@ -12,18 +12,9 @@ UmeShrinkingAExprBenchmark >> initialize [
 	super initialize.
 	grammar := AritExpressionGrammar new.
 	tests := {
-		ShrinkerTest input: '1+(2*3)/0' oracle: DivideZeroOracle new.
-		"ShrinkerTest input: '((8500/(208000*80))+(165468468)*(423-12)*(999/(12+88)))/(((145*4)-580)*3)+((456)*12)-(89/(45+(12*8)))+(77*14)' oracle: DivideZeroOracle new."
+		"ShrinkerTest input: '1+(2*3)/0' oracle: DivideZeroOracle new."
+		ShrinkerTest input: '((8500/(208000*80))+(165468468)*(423-12)*(999/(12+88)))/(((145*4)-580)*3)+((456)*12)-(89/(45+(12*8)))+(77*14)' oracle: DivideZeroOracle new.
 	}
-	"ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
-		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includes: $1) not]).
-		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
-		ShrinkerTest input: '2*3' oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
-		ShrinkerTest input: '3*2' oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
-		ShrinkerTest input: '3' oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
-		ShrinkerTest input: '1+(3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(' ) not]).
-		ShrinkerTest input: '1+(3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '4' ) not]).
-		ShrinkerTest input: '1+(2*3)' oracle: (self oracleByBlock: [ :string | (string includesSubstring: '2' ) not])."
 ]
 
 { #category : 'initialization' }

--- a/Ume/UmeShrinkingBenchmark.class.st
+++ b/Ume/UmeShrinkingBenchmark.class.st
@@ -1,0 +1,70 @@
+Class {
+	#name : 'UmeShrinkingBenchmark',
+	#superclass : 'Object',
+	#instVars : [
+		'shrinkers',
+		'tests',
+		'grammar'
+	],
+	#category : 'Ume-Shrinking',
+	#package : 'Ume',
+	#tag : 'Shrinking'
+}
+
+{ #category : 'instance creation' }
+UmeShrinkingBenchmark class >> for: shrinkerClasses [
+
+	^ self new shrinkers: shrinkerClasses
+]
+
+{ #category : 'initialization' }
+UmeShrinkingBenchmark >> bench [
+
+	^ shrinkers inject: UmeShrinkingBenchmarkReport new into: [ :report :shrinkerClass |
+		report add: (self benchShrinker: shrinkerClass) for: shrinkerClass
+	]
+]
+
+{ #category : 'initialization' }
+UmeShrinkingBenchmark >> benchShrinker: shrinkerClass [
+
+	| results |
+	
+	results := tests collect: [ :test | shrinkerClass new profiledShrink: test input ].
+
+	^ UmeShrinkingBenchmarkReport keys inject: Dictionary new into: [ :result :key |
+		result at: key put: (results collect: [ :report | report at: key ]) average.
+		result
+	]
+]
+
+{ #category : 'accessing' }
+UmeShrinkingBenchmark >> grammar [
+
+	^ grammar 
+]
+
+{ #category : 'accessing' }
+UmeShrinkingBenchmark >> grammar: inputGrammar [
+	
+	grammar := inputGrammar
+]
+
+{ #category : 'initialization' }
+UmeShrinkingBenchmark >> initialize [ 
+
+	super initialize.
+	tests := {}.
+]
+
+{ #category : 'accessing' }
+UmeShrinkingBenchmark >> shrinkers [
+
+	^ shrinkers 
+]
+
+{ #category : 'accessing' }
+UmeShrinkingBenchmark >> shrinkers: shrinkerClasses [
+
+	shrinkers := shrinkerClasses
+]

--- a/Ume/UmeShrinkingBenchmark.class.st
+++ b/Ume/UmeShrinkingBenchmark.class.st
@@ -30,7 +30,10 @@ UmeShrinkingBenchmark >> benchShrinker: shrinkerClass [
 
 	| results |
 	
-	results := tests collect: [ :test | shrinkerClass new profiledShrink: test input ].
+	results := tests collect: [ :test | | shrinker |
+		shrinker := shrinkerClass new grammar: grammar; oracle: test oracle.
+		shrinker profiledShrink: test input.
+	].
 
 	^ UmeShrinkingBenchmarkReport keys inject: Dictionary new into: [ :result :key |
 		result at: key put: (results collect: [ :report | report at: key ]) average.

--- a/Ume/UmeShrinkingBenchmarkReport.class.st
+++ b/Ume/UmeShrinkingBenchmarkReport.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : 'UmeShrinkingBenchmarkReport',
+	#superclass : 'Object',
+	#instVars : [
+		'results'
+	],
+	#category : 'Ume-Shrinking',
+	#package : 'Ume',
+	#tag : 'Shrinking'
+}
+
+{ #category : 'accessing' }
+UmeShrinkingBenchmarkReport class >> keys [
+
+	^ {
+		'totalTime'.
+		'%inputReduction'.
+		'neededReductions'.
+	 	'failedReductions'.
+		'%problemPreservation'
+	}
+]
+
+{ #category : 'adding' }
+UmeShrinkingBenchmarkReport >> add: result for: shrinkerClass [
+
+	results at: shrinkerClass put: result
+]
+
+{ #category : 'adding' }
+UmeShrinkingBenchmarkReport >> initialize [ 
+	
+	super initialize.
+	results := Dictionary new.
+]

--- a/Ume/UmeSimplifyGrammarAlternateReduction.class.st
+++ b/Ume/UmeSimplifyGrammarAlternateReduction.class.st
@@ -70,5 +70,5 @@ UmeSimplifyGrammarAlternateReduction class >> possibleCombination: aListOfLists 
 { #category : 'as yet unclassified' }
 UmeSimplifyGrammarAlternateReduction class >> reduce: subtree using: grammar matching: symbol [
 
-	^ self alternateReduction: subtree using: grammar matchingWith: symbol 
+	^ self alternateReduction: subtree using: grammar matchingWith: symbol
 ]

--- a/Ume/UmeSimplifyGrammarBoth.class.st
+++ b/Ume/UmeSimplifyGrammarBoth.class.st
@@ -5,3 +5,17 @@ Class {
 	#package : 'Ume',
 	#tag : 'Shrinking'
 }
+
+{ #category : 'enumerating' }
+UmeSimplifyGrammarBoth class >> reduce: subtree using: grammar matching: symbol [
+    
+    | candidatesSubtree candidatesAlternate candidates|
+    
+    candidates := OrderedCollection new.
+     
+    candidatesAlternate := (UmeSimplifyGrammarAlternateReduction alternateReduction: subtree using: grammar matchingWith: symbol ).
+    candidatesSubtree := (UmeSimplifyGrammarSubtreeReducer findSubtree: subtree mathchingWith: symbol ).
+    candidates := candidatesSubtree, candidatesAlternate.  
+    
+    ^ candidates sorted: [ :treeA :treeB | treeA treeSize  < treeB treeSize ]
+]

--- a/Ume/UmeSimplifyGrammarBoth.class.st
+++ b/Ume/UmeSimplifyGrammarBoth.class.st
@@ -9,13 +9,13 @@ Class {
 { #category : 'enumerating' }
 UmeSimplifyGrammarBoth class >> reduce: subtree using: grammar matching: symbol [
     
-    | candidatesSubtree candidatesAlternate candidates|
+   | candidatesSubtree candidatesAlternate candidates|
     
-    candidates := OrderedCollection new.
-     
-    candidatesAlternate := (UmeSimplifyGrammarAlternateReduction alternateReduction: subtree using: grammar matchingWith: symbol ).
-    candidatesSubtree := (UmeSimplifyGrammarSubtreeReducer findSubtree: subtree mathchingWith: symbol ).
-    candidates := candidatesSubtree, candidatesAlternate.  
-    
-    ^ candidates sorted: [ :treeA :treeB | treeA treeSize  < treeB treeSize ]
+   candidates := OrderedCollection new.
+   candidatesAlternate := UmeSimplifyGrammarAlternateReduction alternateReduction: subtree using: grammar matchingWith: symbol.
+
+	candidatesSubtree := UmeSimplifyGrammarSubtreeReducer findSubtree: subtree mathchingWith: symbol.
+	candidates := candidatesSubtree, candidatesAlternate.
+
+	^ candidates sorted: [ :treeA :treeB | treeA treeSize  < treeB treeSize ]
 ]

--- a/Ume/UmeSimplifyStringTest.class.st
+++ b/Ume/UmeSimplifyStringTest.class.st
@@ -15,7 +15,7 @@ UmeSimplifyStringTest >> setUp [
 
 	super setUp.
 	shrinker := UmeDeltaDebugger new.	
-	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $e) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $e) ]).
 
 ]
 
@@ -47,7 +47,7 @@ UmeSimplifyStringTest >> testString04 [
 UmeSimplifyStringTest >> testString05 [
 
 	shrinker oracle: (self oracleByBlock: [ :string |
-			 ((string includes: $e) and: (string includes: $a)) not ]).
+			 (string includes: $e) and: (string includes: $a) ]).
 
 	self
 		assert: (shrinker shrink: 'kjdsfhkjqsdhfehdkjsqfhkjsa')

--- a/Ume/UmeSimplifyStringTest.class.st
+++ b/Ume/UmeSimplifyStringTest.class.st
@@ -15,7 +15,7 @@ UmeSimplifyStringTest >> setUp [
 
 	super setUp.
 	shrinker := UmeDeltaDebugger new.	
-	shrinker oracle: (UmeBooleanInputOracle from: [ :string | (string includes: $e) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $e) not]).
 
 ]
 
@@ -45,16 +45,11 @@ UmeSimplifyStringTest >> testString04 [
 
 { #category : 'running' }
 UmeSimplifyStringTest >> testString05 [
-	
-	shrinker splittingValue: 3.
 
-	self assert: (shrinker shrink: 'eqlbfkdjbkj') equals: 'eq'
-]
+	shrinker oracle: (self oracleByBlock: [ :string |
+			 ((string includes: $e) and: (string includes: $a)) not ]).
 
-{ #category : 'running' }
-UmeSimplifyStringTest >> testString06 [
-	
-	shrinker oracle: [ :string | ((string includes: $e) and: (string includes: $a) ) not].
-	
-	self assert: (shrinker shrink: 'kjdsfhkjqsdhfehdkjsqfhkjsa') equals: 'ea'
+	self
+		assert: (shrinker shrink: 'kjdsfhkjqsdhfehdkjsqfhkjsa')
+		equals: 'ea'
 ]

--- a/Ume/UmeSimplifyStringTest.class.st
+++ b/Ume/UmeSimplifyStringTest.class.st
@@ -15,7 +15,7 @@ UmeSimplifyStringTest >> setUp [
 
 	super setUp.
 	shrinker := UmeDeltaDebugger new.	
-	shrinker oracle: [ :string | (string includes: $e) not].
+	shrinker oracle: (UmeBooleanInputOracle from: [ :string | (string includes: $e) not]).
 
 ]
 
@@ -63,6 +63,7 @@ UmeSimplifyStringTest >> testString04 [
 UmeSimplifyStringTest >> testString05 [
 	
 	shrinker splittingValue: 3.
+
 	self assert: (shrinker shrink: 'eqlbfkdjbkj') equals: 'eq'
 ]
 

--- a/Ume/UmeStrategyShrinkerTest.class.st
+++ b/Ume/UmeStrategyShrinkerTest.class.st
@@ -22,7 +22,7 @@ UmeStrategyShrinkerTest >> setUp [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer00 [ 
 
-	shrinker oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | string includesSubstring: '(3)' ]).
 	shrinker reductionStrategy: UmeSimplifyGrammarAlternateReduction . 
 	
 	self assert:  (shrinker shrink: '1+(2*3)' ) equals: '(3)'
@@ -31,7 +31,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer00 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer01 [
 
-	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $1) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | string includes: $1 ]).
 	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
 	
 	self assert:  (shrinker shrink: '1+(2*3)' ) equals: '1'
@@ -40,7 +40,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer01 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer02 [
 	
-	shrinker oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | string includesSubstring: '(3)' ]).
 	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
 	
 	self assert:  (shrinker shrink: '1+(2*3)' ) equals: '(3)'
@@ -49,7 +49,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer02 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer03 [
 
-	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | string includes: $3 ]).
 	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
 	
 	self assert:  (shrinker shrink: '2*3' ) equals: '3'
@@ -58,7 +58,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer03 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer04 [
 
-	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | string includes: $3 ]).
 	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
 
 	self assert:  (shrinker shrink: '3*2' ) equals: '3'
@@ -67,7 +67,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer04 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer05 [
 
-	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | string includes: $3 ]).
 	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
 	
 	self assert:  (shrinker shrink: '3' ) equals: '3'
@@ -76,7 +76,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer05 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer06 [
 
-	shrinker oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(' ) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | string includesSubstring: '(' ]).
 	shrinker reductionStrategy: UmeSimplifyGrammarSubtreeReducer . 
 	
 	self assert:  (shrinker shrink: '1+(3)' ) equals: '(3)'
@@ -85,7 +85,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer06 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer07 [
 
-	shrinker oracle: (self oracleByBlock: [ :string | (string includesSubstring: '4' ) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | string includesSubstring: '4' ]).
 	shrinker reductionStrategy: UmeSimplifyGrammarSubtreeReducer . 
 	
 	self assert:  (shrinker shrink: '1+(3)' ) equals: '1+(3)'
@@ -94,7 +94,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer07 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer08 [
 
-	shrinker oracle: (self oracleByBlock: [ :string | (string includesSubstring: '2' ) not]).
+	shrinker oracle: (self oracleByBlock: [ :string | string includesSubstring: '2' ]).
 	shrinker reductionStrategy: UmeSimplifyGrammarAlternateReduction . 
 
 	self assert:  (shrinker shrink: '1+(2*3)' ) equals: '2'

--- a/Ume/UmeStrategyShrinkerTest.class.st
+++ b/Ume/UmeStrategyShrinkerTest.class.st
@@ -22,7 +22,7 @@ UmeStrategyShrinkerTest >> setUp [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer00 [ 
 
-	shrinker oracle: [ :string | (string includesSubstring: '(3)' ) not].
+	shrinker oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
 	shrinker reductionStrategy: UmeSimplifyGrammarAlternateReduction . 
 	
 	self assert:  (shrinker shrink: '1+(2*3)' ) equals: '(3)'
@@ -31,7 +31,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer00 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer01 [
 
-	shrinker oracle: [ :string | (string includes: $1) not].
+	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $1) not]).
 	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
 	
 	self assert:  (shrinker shrink: '1+(2*3)' ) equals: '1'
@@ -40,7 +40,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer01 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer02 [
 	
-	shrinker oracle: [ :string | (string includesSubstring: '(3)' ) not].
+	shrinker oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(3)' ) not]).
 	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
 	
 	self assert:  (shrinker shrink: '1+(2*3)' ) equals: '(3)'
@@ -49,7 +49,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer02 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer03 [
 
-	shrinker oracle: [ :string | (string includes: $3) not].
+	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
 	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
 	
 	self assert:  (shrinker shrink: '2*3' ) equals: '3'
@@ -58,16 +58,16 @@ UmeStrategyShrinkerTest >> testGrammarReducer03 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer04 [
 
-	shrinker oracle: [ :string | (string includes: $3) not].
+	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
 	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
-	
+
 	self assert:  (shrinker shrink: '3*2' ) equals: '3'
 ]
 
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer05 [
 
-	shrinker oracle: [ :string | (string includes: $3) not].
+	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $3) not]).
 	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
 	
 	self assert:  (shrinker shrink: '3' ) equals: '3'
@@ -76,7 +76,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer05 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer06 [
 
-	shrinker oracle: [ :string | (string includesSubstring: '(' ) not].
+	shrinker oracle: (self oracleByBlock: [ :string | (string includesSubstring: '(' ) not]).
 	shrinker reductionStrategy: UmeSimplifyGrammarSubtreeReducer . 
 	
 	self assert:  (shrinker shrink: '1+(3)' ) equals: '(3)'
@@ -85,7 +85,7 @@ UmeStrategyShrinkerTest >> testGrammarReducer06 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer07 [
 
-	shrinker oracle: [ :string | (string includesSubstring: '4' ) not].
+	shrinker oracle: (self oracleByBlock: [ :string | (string includesSubstring: '4' ) not]).
 	shrinker reductionStrategy: UmeSimplifyGrammarSubtreeReducer . 
 	
 	self assert:  (shrinker shrink: '1+(3)' ) equals: '1+(3)'
@@ -94,8 +94,8 @@ UmeStrategyShrinkerTest >> testGrammarReducer07 [
 { #category : 'tests' }
 UmeStrategyShrinkerTest >> testGrammarReducer08 [
 
-	shrinker oracle: [ :string | (string includesSubstring: '2' ) not].
+	shrinker oracle: (self oracleByBlock: [ :string | (string includesSubstring: '2' ) not]).
 	shrinker reductionStrategy: UmeSimplifyGrammarAlternateReduction . 
-	
+
 	self assert:  (shrinker shrink: '1+(2*3)' ) equals: '2'
 ]


### PR DESCRIPTION
### Shrinking Benchmarking

In this pr, we implement an isolated Shrinking Benchmark logic.
The idea is to easily extend and create a Shrinking Benchmark given a test suite.

Here is a little example of how it works:

```st
| shrinkerClasses benchmark report |
shrinkerClasses := {
	UmeDeltaDebugger.
	UmeGRABRShrinker.
	UmeGrammarBasedShrinker
}.

benchmark := UmeShrinkingAExprBenchmark for: shrinkerClasses.
report := benchmark bench.
```