### PR TITLE
Benchmark comparison visualization

### DIFF
--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -152,7 +152,7 @@ UmeShrinker >> profiledShrink: input [
 	^ {
 		'originalInput' -> input.
 		'minimizedInput' -> minimizedInput.
-		'totalTime' -> ((Duration microSeconds: totalTime) "asString").
+		'totalTime' -> (Duration microSeconds: totalTime).
 		'neededReductions' -> reductionsDone asFloat.
 		'failedReductions' -> failedReductionsDone asFloat.
 		'%problemPreservation' -> (self percentageProblemPreservation: upperBound given: minimizedBound).

--- a/Ume/UmeShrinker.class.st
+++ b/Ume/UmeShrinker.class.st
@@ -152,7 +152,7 @@ UmeShrinker >> profiledShrink: input [
 	^ {
 		'originalInput' -> input.
 		'minimizedInput' -> minimizedInput.
-		'totalTime' -> ((Duration microSeconds: totalTime) asString).
+		'totalTime' -> ((Duration microSeconds: totalTime) "asString").
 		'neededReductions' -> reductionsDone asFloat.
 		'failedReductions' -> failedReductionsDone asFloat.
 		'%problemPreservation' -> (self percentageProblemPreservation: upperBound given: minimizedBound).

--- a/Ume/UmeShrinkingBenchmarkReport.class.st
+++ b/Ume/UmeShrinkingBenchmarkReport.class.st
@@ -18,20 +18,46 @@ UmeShrinkingBenchmarkReport >> add: result for: shrinkerClass [
 { #category : 'as yet unclassified' }
 UmeShrinkingBenchmarkReport >> asPlots: section [ 
 
-	| plt p |
-	plt := RSCompositeChart new.
+	| plt p colors |
+	plt := RSChart new.
+	colors := { Color blue . Color red . Color green . Color orange . Color purple . Color cyan }.
 	
-	results do: [ :data | 
+	results doWithIndex: [ :data :index | 
 		p := RSLinePlot new x: ( 1 to: data size ) y: ( self collectResult: data for: section ).
+		p color: (colors atWrap: index).
+		p marker: (RSEllipse new size: 4; color: (colors atWrap: index)).
 		plt add: p
-		].
+	].
 
 	plt xlabel: 'test number';
 	ylabel: section;
-	title: section, 'Benchmark';
+	title: section, ' benchmark';
 	build.
 
-	^ plt
+	self buildLegend: plt with: section palette: colors. 
+
+	^ plt canvas 
+]
+
+{ #category : 'as yet unclassified' }
+UmeShrinkingBenchmarkReport >> buildLegend: plot with: section palette: colors [
+	
+	| legend |
+	
+	legend := RSLegend new.
+	legend container: plot canvas;
+	title: 'Legend'.
+	
+	results doWithIndex: [ :data :index |
+		| name |
+		name := (results keyAtValue: data) asString.
+		legend text: name withBoxColor: (colors atWrap: index)
+	].
+	
+   legend legendDo: [ :l | 
+        l withBorder; padding: 10 ].
+    legend location right; middle; offset: 10@0.
+    legend build.
 ]
 
 { #category : 'as yet unclassified' }

--- a/Ume/UmeShrinkingBenchmarkReport.class.st
+++ b/Ume/UmeShrinkingBenchmarkReport.class.st
@@ -63,6 +63,9 @@ UmeShrinkingBenchmarkReport >> buildLegend: plot with: section palette: colors [
 { #category : 'as yet unclassified' }
 UmeShrinkingBenchmarkReport >> collectResult: result for: section [
 
+	( section = 'totalTime' ) ifTrue: [ 
+		^ result collect: [ :r | (r at: section) asMicroseconds ]  ].
+	
 	^ result collect: [ :r | r at: section ]
 ]
 
@@ -100,7 +103,7 @@ UmeShrinkingBenchmarkReport >> plotProblemPreservation [
 { #category : 'as yet unclassified' }
 UmeShrinkingBenchmarkReport >> plotTotalTime [
 
-	^ (self asPlots: 'totalTime') open
+	^ (self asPlots: 'totalTime' ) open
 ]
 
 { #category : 'as yet unclassified' }

--- a/Ume/UmeShrinkingBenchmarkReport.class.st
+++ b/Ume/UmeShrinkingBenchmarkReport.class.st
@@ -18,33 +18,26 @@ UmeShrinkingBenchmarkReport >> add: result for: shrinkerClass [
 { #category : 'as yet unclassified' }
 UmeShrinkingBenchmarkReport >> asPlots: section [ 
 
-	| plt p x y |
+	| plt p |
 	plt := RSCompositeChart new.
 	
-	results do: [ :res | 
-		x := 1 to: res size. 
-		y := self collectResult: res for: section.
-		p := RSLinePlot new x: x y: y.
+	results do: [ :data | 
+		p := RSLinePlot new x: ( 1 to: data size ) y: ( self collectResult: data for: section ).
 		plt add: p
 		].
 
-	plt xlabel: 'test number'.
-	plt ylabel: section.
-	plt title: section, ' benchmark'."
-	plt verticalTick integer numberOfTicks: 1."
-	
-	plt build.
+	plt xlabel: 'test number';
+	ylabel: section;
+	title: section, 'Benchmark';
+	build.
+
 	^ plt
 ]
 
 { #category : 'as yet unclassified' }
 UmeShrinkingBenchmarkReport >> collectResult: result for: section [
 
-	| res |
-	res := OrderedCollection new. 
-	result do: [ :r | res add: (r at: section) ].
-	^ res. 
-	
+	^ result collect: [ :r | r at: section ]
 ]
 
 { #category : 'adding' }

--- a/Ume/UmeShrinkingBenchmarkReport.class.st
+++ b/Ume/UmeShrinkingBenchmarkReport.class.st
@@ -18,21 +18,34 @@ UmeShrinkingBenchmarkReport >> add: result for: shrinkerClass [
 { #category : 'as yet unclassified' }
 UmeShrinkingBenchmarkReport >> asPlots: section [ 
 
-	| plt p colors |
+	| plt p colors count |
 	plt := RSChart new.
 	colors := { Color blue . Color red . Color green . Color orange . Color purple . Color cyan }.
 	
-	results doWithIndex: [ :data :index | 
-		p := RSLinePlot new x: ( 1 to: data size ) y: ( self collectResult: data for: section ).
-		p color: (colors atWrap: index).
+	count := results size.
+	colors := (1 to: count) collect: [ :i | 
+        Color 
+            h: ((i - 1) * 360 / (count max: 1))
+            s: 0.75
+            v: 0.85
+    ].
+	
+	results doWithIndex: [ :data :index |
+		p := RSLinePlot new x: ( 1 to: data size ) y: (self collectResult: data for: section).
+		p color: (colors at: index).
 		p marker: (RSEllipse new size: 4; color: (colors atWrap: index)).
 		plt add: p
 	].
 
 	plt xlabel: 'test number';
-	ylabel: section;
-	title: section, ' benchmark';
-	build.
+	yLog; 
+	ylabel: section, ' (log)';
+	title: section, ' benchmark'.
+	
+	plt horizontalTick numberOfTicks: ((results anyOne size) min: 10).
+	plt horizontalTick labelConversion: [ :val | val rounded ].
+
+	plt build.
 
 	self buildLegend: plt with: section palette: colors. 
 
@@ -51,11 +64,11 @@ UmeShrinkingBenchmarkReport >> buildLegend: plot with: section palette: colors [
 	results doWithIndex: [ :data :index |
 		| name |
 		name := (results keyAtValue: data) asString.
-		legend text: name withBoxColor: (colors atWrap: index)
+		legend text: name withBoxColor: (colors at: index)
 	].
 	
-   legend legendDo: [ :l | 
-        l withBorder; padding: 10 ].
+   legend legendDo: [ :legendName | 
+        legendName withBorder; padding: 10 ].
     legend location right; middle; offset: 10@0.
     legend build.
 ]
@@ -64,9 +77,9 @@ UmeShrinkingBenchmarkReport >> buildLegend: plot with: section palette: colors [
 UmeShrinkingBenchmarkReport >> collectResult: result for: section [
 
 	( section = 'totalTime' ) ifTrue: [ 
-		^ result collect: [ :r | (r at: section) asMicroseconds ]  ].
+		^ result collect: [ :aResultAssociation | (aResultAssociation at: section) asMicroseconds ]  ].
 	
-	^ result collect: [ :r | r at: section ]
+	^ result collect: [ :aResultAssociation | aResultAssociation at: section ]
 ]
 
 { #category : 'adding' }

--- a/Ume/UmeShrinkingBenchmarkReport.class.st
+++ b/Ume/UmeShrinkingBenchmarkReport.class.st
@@ -15,11 +15,73 @@ UmeShrinkingBenchmarkReport >> add: result for: shrinkerClass [
 	results at: shrinkerClass name put: result
 ]
 
+{ #category : 'as yet unclassified' }
+UmeShrinkingBenchmarkReport >> asPlots: section [ 
+
+	| plt p x y |
+	plt := RSCompositeChart new.
+	
+	results do: [ :res | 
+		x := 1 to: res size. 
+		y := self collectResult: res for: section.
+		p := RSLinePlot new x: x y: y.
+		plt add: p
+		].
+
+	plt xlabel: 'test number'.
+	plt ylabel: section.
+	plt title: section, ' benchmark'."
+	plt verticalTick integer numberOfTicks: 1."
+	
+	plt build.
+	^ plt
+]
+
+{ #category : 'as yet unclassified' }
+UmeShrinkingBenchmarkReport >> collectResult: result for: section [
+
+	| res |
+	res := OrderedCollection new. 
+	result do: [ :r | res add: (r at: section) ].
+	^ res. 
+	
+]
+
 { #category : 'adding' }
 UmeShrinkingBenchmarkReport >> initialize [ 
 	
 	super initialize.
 	results := Dictionary new.
+]
+
+{ #category : 'as yet unclassified' }
+UmeShrinkingBenchmarkReport >> plotFailedReductions [
+
+	^ (self asPlots: 'failedReductions') open
+]
+
+{ #category : 'as yet unclassified' }
+UmeShrinkingBenchmarkReport >> plotInputReduction [
+
+	^ (self asPlots: '%inputReduction') open
+]
+
+{ #category : 'as yet unclassified' }
+UmeShrinkingBenchmarkReport >> plotNeededIterations [
+
+	^ (self asPlots: 'neededReductions') open
+]
+
+{ #category : 'as yet unclassified' }
+UmeShrinkingBenchmarkReport >> plotProblemPreservation [
+
+	^ (self asPlots: '%problemPreservation') open
+]
+
+{ #category : 'as yet unclassified' }
+UmeShrinkingBenchmarkReport >> plotTotalTime [
+
+	^ (self asPlots: 'totalTime') open
 ]
 
 { #category : 'as yet unclassified' }


### PR DESCRIPTION
## Benchmark comparison using Roassal 
The main objective is to visualize and summarize the difference between shrinking algorithms based on different data.

### Example
You first have to run a benchmark to have a benchmark report
``` st
shrinkerClasses := {
        UmeGRABRShrinker .
        UmeDeltaDebugger .
	UmeNautilusShrinker 
}.

benchmark := UmeShrinkingSVGBenchmark for: shrinkerClasses.
benchmark bench
```
We can now visualize the results so we can compare the different classes easily. It works by using:
 `plotNeededIterations`, `plotFailedReductions`, `plotTotalTime`, `plotInputReduction` or `plotProblemPreservation`.
As a result, you have a canvas window such as: 
 
<img width="1800" height="417" alt="image" src="https://github.com/user-attachments/assets/446e1b9f-8ae6-4fe5-bc68-ece147e197a0" />

