### PR TITLE
Improving anf fixing HDD

### DIFF
--- a/Ume/UmeDeltaDebugger.class.st
+++ b/Ume/UmeDeltaDebugger.class.st
@@ -22,7 +22,7 @@ UmeDeltaDebugger >> getComplement: input start: start length: subsetLength [
 	complement := (input copyFrom: 1 to: start) , 
                  (input copyFrom: (start + subsetLength + 1 min: input size + 1) to: input size).
 
-	^ complement. 
+	^ complement 
 ]
 
 { #category : 'testing' }
@@ -84,7 +84,7 @@ UmeDeltaDebugger >> sizeOf: string [
 { #category : 'shrinking' }
 UmeDeltaDebugger >> tree: aString [
 
-	^ aString. 
+	^ aString
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeGRABRShrinker.class.st
+++ b/Ume/UmeGRABRShrinker.class.st
@@ -20,14 +20,14 @@ UmeGRABRShrinker >> asInput: tree [
 { #category : 'shrinking' }
 UmeGRABRShrinker >> candidates: subTree matching: symbol [
 
-	| allCandidates difference |
+	| allCandidates candidatesList |
 	
 	allCandidates := (reductionStrategy reduce: subTree using: grammar matching: symbol depth: depth) asSet.
 
-	difference := (allCandidates difference: seen) asOrderedCollection.
-	difference sort: [ :treeA :treeB | treeA treeSize  < treeB treeSize ]. 
+	candidatesList := allCandidates asOrderedCollection.
+	candidatesList sort: [ :treeA :treeB | treeA treeSize  < treeB treeSize ]. 
 	
-	^ difference
+	^ candidatesList
 ]
 
 { #category : 'shrinking' }
@@ -47,24 +47,21 @@ UmeGRABRShrinker >> minimizeOne: originalTree upperBound: bound [
 
 	tree := originalTree.
 	found := false.
-
 	[tree treeHeight > depth] whileTrue: [
 		tree allNodes doWithIndex: [ :subTree :index |
-			( subTree isLeaf ) ifFalse: [ | symbol |
+			( subTree isLeaf ) ifFalse: [ | symbol |	
 				symbol := subTree tag. 
-				(self candidates: subTree matching: symbol) do: [ :candidate |
-					( seen includes: candidate ) 
-					ifFalse: [ 
-						seen add: candidate. 
-						( candidate treeSize < subTree treeSize) 
-						ifTrue: [ | newTree |
-							newTree := self replaceSubtreeIn: tree by: candidate index: index.
+				(self candidates: subTree matching: symbol) do: [ :candidate | | newTree |
+					(candidate treeSize < subTree treeSize ) ifTrue: [ 
+						newTree := self replaceSubtreeIn: tree by: candidate index: index.	
+						( seen includes: newTree ) 
+						ifFalse: [ 
+							seen add: candidate. 
 							self minimizationDone.
 							(self triggerBug: newTree upperBound: bound ) ifTrue: [
 								tree := newTree.
 								found := true.
 								self restartDepth.
-
 								^ self minimizeOne: tree upperBound: bound.
 							] ifFalse: [ self failedMinimization ]
 						]

--- a/Ume/UmeHDDShrinker.class.st
+++ b/Ume/UmeHDDShrinker.class.st
@@ -17,39 +17,18 @@ UmeHDDShrinker >> getComplement: input start: start length: subsetLength [
 	complement := (input copyFrom: 1 to: start) , 
                  (input copyFrom: (start + subsetLength + 1 min: input size + 1) to: input size).
 
-	^ complement. 
+	^ complement 
 ]
 
 { #category : 'shrinking' }
-UmeHDDShrinker >> hddmin: tree upperBound: bound level: level [
-	
-		| candidates |
-
-		candidates := tree allNodesAtLevel: level.
-		(candidates size <= 1) ifTrue: [ ^ nil ].
-		
-		1 to: (candidates size) do: [ :k |
-			candidates combinations: k atATimeDo: [ :toMinimize |
-				(seen includes: toMinimize) ifFalse: [ 
-					seen add: toMinimize.
-					self minimizationDone.
-					(self hddmin: tree withSubset: toMinimize bound: bound) ifTrue: [ ^ nil ] ifFalse: [
-						self failedMinimization.
-					]
-				]
-			]
-		]
-]
-
-{ #category : 'shrinking' }
-UmeHDDShrinker >> hddmin: tree withSubset: toMinimize bound: bound [
+UmeHDDShrinker >> hddmin: tree removeNodes: nodesToRemove bound: bound [
 
 	| reduced parents |
 	
 	reduced := false.
 	parents := Dictionary new.
 
-	toMinimize do: [ :node | | parent |
+	nodesToRemove do: [ :node | | parent |
 		parent := node parent.
 		parent ifNotNil: [
 			"saving parents with original children to revert later"
@@ -71,6 +50,42 @@ UmeHDDShrinker >> hddmin: tree withSubset: toMinimize bound: bound [
 	].
 	
 	^ reduced
+]
+
+{ #category : 'shrinking' }
+UmeHDDShrinker >> hddmin: tree upperBound: bound level: level [
+	
+		| candidates granularity |
+
+		candidates := tree allNodesAtLevel: level.
+		(candidates size <= 1) ifTrue: [ ^ nil ].
+		granularity := 2.
+		
+		[ granularity <= candidates size ] whileTrue: [ 
+			| start subsetLength someComplementFailing |
+			start := 0.
+			subsetLength := (candidates size // granularity) max: 1.
+			someComplementFailing := false.
+			[ start < candidates size ] whileTrue: [ | complement nodesToRemove |
+				self minimizationDone.
+				complement := self getComplement: candidates start: start length: subsetLength .
+				nodesToRemove := candidates reject: [ :node | complement includes: node ].
+				(self hddmin: tree removeNodes: nodesToRemove bound: bound) ifTrue: [ 
+					candidates := complement.
+					granularity := (granularity -1) max: 2.
+					someComplementFailing := true.
+					start := candidates size.
+				] ifFalse: [
+					self failedMinimization.
+					start := start + subsetLength.
+				]
+			].
+			someComplementFailing ifFalse: [
+				granularity = candidates size ifTrue: [ ^ nil ].
+				granularity := (granularity * 2) min: candidates size 
+			].
+		].
+
 ]
 
 { #category : 'shrinking' }

--- a/Ume/UmeHDDShrinker.class.st
+++ b/Ume/UmeHDDShrinker.class.st
@@ -11,10 +11,20 @@ Class {
 }
 
 { #category : 'shrinking' }
+UmeHDDShrinker >> getComplement: input start: start length: subsetLength [
+
+	| complement |
+	complement := (input copyFrom: 1 to: start) , 
+                 (input copyFrom: (start + subsetLength + 1 min: input size + 1) to: input size).
+
+	^ complement. 
+]
+
+{ #category : 'shrinking' }
 UmeHDDShrinker >> hddmin: tree upperBound: bound level: level [
 	
 		| candidates |
-		
+
 		candidates := tree allNodesAtLevel: level.
 		(candidates size <= 1) ifTrue: [ ^ nil ].
 		
@@ -77,10 +87,11 @@ UmeHDDShrinker >> minimizeOne: originalTree upperBound: bound [
 
 	tree := self tree: originalTree asInput.
 
-	currentLevel := tree treeHeight - 1.
-   [ currentLevel >= 1 ] whileTrue: [ 
+	currentLevel := 1.
+	
+   [ currentLevel <= tree treeHeight ] whileTrue: [ 
 		self hddmin: tree upperBound: bound level: currentLevel.		
-		currentLevel := currentLevel - 1.
+		currentLevel := currentLevel + 1.
 	].
 
 	^ tree

--- a/Ume/UmeHDDTest.class.st
+++ b/Ume/UmeHDDTest.class.st
@@ -14,6 +14,7 @@ Class {
 UmeHDDTest >> setUp [
 
 	super setUp.
+	super timeLimit: 3 minutes. 
 	shrinker := UmeHDDShrinker new.
 	grammar := AritExpressionGrammar new.
 	shrinker grammar: grammar.
@@ -89,4 +90,19 @@ UmeHDDTest >> testHDDReducer08 [
 	shrinker oracle: (self oracleByBlock: [ :string | (string includes: $3) and: [(string includes: $1)] ]).
 	
 	self assert:  ( shrinker shrink: '1+(2*3)' ) equals: '13'
+]
+
+{ #category : 'tests' }
+UmeHDDTest >> testHDDReducer09 [
+
+	| oracle res input |
+	oracle := PerformanceOracle new evalBlock: [ :path | SVGRunner run: path ].
+	
+	shrinker oracle: oracle.
+	shrinker grammar: SvgPathGrammar new.
+	
+	input := 'm-.99,-.4,7-933.,03-.8 -319.9-.62449 -1742 -269 -747 -5 16.-132 21.04-55.9'.
+	res := shrinker shrink: input.
+	
+	self assert:  (shrinker shrink: input) size < (input size)
 ]

--- a/Ume/UmeStrategyShrinkerTest.class.st
+++ b/Ume/UmeStrategyShrinkerTest.class.st
@@ -156,3 +156,18 @@ UmeStrategyShrinkerTest >> testGrammarReducer12 [
 	
 	self assert:  res equals: 'm2-5'
 ]
+
+{ #category : 'tests' }
+UmeStrategyShrinkerTest >> testGrammarReducer13 [
+
+	| oracle res input |
+	oracle := PerformanceOracle new threshold: 0.9; evalBlock: [ :path | SVGRunner run: path ].
+
+	shrinker oracle: oracle.
+	shrinker grammar: SvgPathGrammar new.
+	shrinker reductionStrategy: UmeSimplifyGrammarBoth.
+	input := 'm-.99,-.4,7-93.,03-.8 -19.9-.2449 -1742 -269 -747 -5 16.-132 21.04-55.9'.
+	res := shrinker shrink: input.
+	
+	self assert: res size < (input size)
+]


### PR DESCRIPTION
# Hierarchical Delta Debugging
This pull request resolves some issues with the currently implemented HDD algorithm, beginning with starting to search for reduction from the root to the leaves insteed. 
Then, I changed our current logic to match with the state-of-the-art delta debugger algorithm (`ddmin`).

The main difference is: 
- It starts searching for reduction from top to bottom. 
- It doesn't try every deleting possibility (because it's costly on huge trees); instead, we have a divide and conquer mindset using the state-of-the-art delta debugging logic.

## metrics comparison

<img width="632" height="361" alt="image" src="https://github.com/user-attachments/assets/ec12895d-abe7-42a1-924d-8eddf9b89db3" />

<img width="631" height="357" alt="image" src="https://github.com/user-attachments/assets/0a0faeca-c61f-42a8-b6cf-e77ef5606333" />


<img width="621" height="356" alt="image" src="https://github.com/user-attachments/assets/93671e38-e002-4969-b40c-9f284f8c4b20" />
