### PR TITLE
Better implementation of MOpt

### DIFF
--- a/Ume/GrammarBasePathologicalBugMutatorPaperExperiment.class.st
+++ b/Ume/GrammarBasePathologicalBugMutatorPaperExperiment.class.st
@@ -235,6 +235,18 @@ GrammarBasePathologicalBugMutatorPaperExperiment >> targetMethod [
 	self subclassResponsibility 
 ]
 
+{ #category : 'accessing' }
+GrammarBasePathologicalBugMutatorPaperExperiment >> times [
+
+	^ times
+]
+
+{ #category : 'accessing' }
+GrammarBasePathologicalBugMutatorPaperExperiment >> times: anObject [
+
+	times := anObject
+]
+
 { #category : 'running' }
 GrammarBasePathologicalBugMutatorPaperExperiment >> weightSelectionSchedulerSchema [
 

--- a/Ume/UmeMOPTMutatorSelector.class.st
+++ b/Ume/UmeMOPTMutatorSelector.class.st
@@ -2,31 +2,42 @@ Class {
 	#name : 'UmeMOPTMutatorSelector',
 	#superclass : 'UmeMutatorSelector',
 	#instVars : [
-		'probabilities',
 		'selectionCounts',
 		'successCounts',
-		'velocities',
-		'lastIndex',
 		'updatePeriod',
 		'selectionCounter',
 		'omega',
 		'phi',
 		'random',
-		'localBestEfficiencies',
-		'localBestProbabilities',
 		'maxProbability',
-		'minProbability'
+		'minProbability',
+		'numberOfSwarms',
+		'swarms',
+		'lastMutatedSelector',
+		'pilotPhaseMax'
 	],
 	#category : 'Ume-Selector Heuristics',
 	#package : 'Ume',
 	#tag : 'Selector Heuristics'
 }
 
+{ #category : 'accessing' }
+UmeMOPTMutatorSelector >> bestSwarm [
+
+	| bestEfficiency bestSwarm |
+	bestEfficiency := Float negativeInfinity.
+	swarms do: [ :swarm |
+			swarm efficiency > bestEfficiency ifTrue: [
+					bestEfficiency := swarm efficiency.
+					bestSwarm := swarm ] ].
+	^ bestSwarm
+]
+
 { #category : 'feedback' }
 UmeMOPTMutatorSelector >> feed: feedback [
 
-	(((feedback isNotNil) and: [ feedback isPositive ]) and: [ lastIndex isNotNil ]) ifTrue: [ 
-			successCounts at: lastIndex put: (successCounts at: lastIndex) + 1
+	(((feedback isNotNil) and: [ feedback isPositive ]) and: [ lastMutatedSelector isNotNil ]) ifTrue: [ 
+			successCounts at: lastMutatedSelector put: (successCounts at: lastMutatedSelector) + 1
 	]
 ]
 
@@ -34,45 +45,81 @@ UmeMOPTMutatorSelector >> feed: feedback [
 UmeMOPTMutatorSelector >> initialize [
 
 	super initialize.
+	
+	numberOfSwarms := 10.
+	
 	omega := 0.72.
 	phi := 1.5.
 	updatePeriod := 100.
 	selectionCounter := 0.
 	successCounts := {}.
-	random := Random new
+	random := Random new.
+	
+	"how many warm up executions should be done to get the swarms up and running"
+	pilotPhaseMax := 100.
 ]
 
 { #category : 'initialization' }
-UmeMOPTMutatorSelector >> initializeProbabilities: mutators [
+UmeMOPTMutatorSelector >> initializeSwarms: mutators [
 
 	| count uniform |
 
 	count := mutators size.
+	
+	swarms := (1 to: numberOfSwarms) collect: [ :i |
+		UmeMOPTSwarm new
+			mopt: self;
+			initializeSwarm: mutators;
+			yourself
+	].
+	
 	uniform := 1.0 / count asFloat.
 	
-	localBestEfficiencies := Array new: count withAll: 0.
-	localBestProbabilities := Array new: count withAll: 0.
 	minProbability := 0.001.
 	maxProbability := 0.998.
 	
-	probabilities := (1 to: count) collect: [ :i | uniform ].
 	selectionCounts := Array new: count withAll: 0.
 	successCounts := Array new: count withAll: 0.
-	velocities := Array new: count withAll: 0.0.
-	lastIndex := 1.
+	lastMutatedSelector := 1.
 	selectionCounter := 0.
 ]
 
 { #category : 'accessing' }
 UmeMOPTMutatorSelector >> lastSelectedIndex [
 
-	^ lastIndex
+	^ lastMutatedSelector
+]
+
+{ #category : 'accessing' }
+UmeMOPTMutatorSelector >> maxProbability [
+
+	^ maxProbability
+]
+
+{ #category : 'accessing' }
+UmeMOPTMutatorSelector >> maxProbability: anObject [
+
+	maxProbability := anObject
+]
+
+{ #category : 'accessing' }
+UmeMOPTMutatorSelector >> minProbability [
+
+	^ minProbability
+]
+
+{ #category : 'accessing' }
+UmeMOPTMutatorSelector >> minProbability: anObject [
+
+	minProbability := anObject
 ]
 
 { #category : 'accessing' }
 UmeMOPTMutatorSelector >> mutatorWeights [
 
-	^ probabilities"selectionCounts"
+	"This may be called before the swarms are initialized??"
+	swarms ifNil: [ ^ nil ].
+	^ self bestSwarm probabilities
 ]
 
 { #category : 'accessing' }
@@ -100,12 +147,6 @@ UmeMOPTMutatorSelector >> phi: aFloat [
 ]
 
 { #category : 'accessing' }
-UmeMOPTMutatorSelector >> probabilities [
-
-	^ probabilities
-]
-
-{ #category : 'accessing' }
 UmeMOPTMutatorSelector >> random [
 
 	^ random
@@ -113,39 +154,34 @@ UmeMOPTMutatorSelector >> random [
 
 { #category : 'enumerating' }
 UmeMOPTMutatorSelector >> selectMutator: mutators [
-
-	| total roll cumulative |
-
 	"if the probabilities were not assigned, we initialize them uniformly"
-	(probabilities isNil or: [ probabilities size ~= mutators size ]) ifTrue: [
-		self initializeProbabilities: mutators.
-	].
 
-	"get the total probability sum"
-	total := probabilities sum.
-	"throw a coin"
-	roll := total * random next.
-	cumulative := 0.0.
+	| swarm isPilotPhase |
+	swarms isNil ifTrue: [ self initializeSwarms: mutators ].
 
-	"look for the lucky one"
-	probabilities withIndexDo: [ :prob :index |
-		cumulative := cumulative + prob.
-		roll <= cumulative ifTrue: [
-			"found, now we update the last selected and the counter"
-			lastIndex := index.
-			selectionCounts at: index put: (selectionCounts at: index) + 1.
-			selectionCounter := selectionCounter + 1.
-			selectionCounter >= updatePeriod ifTrue: [ self updateProbabilities ].
-	
-			"return the lucky one"
-			^ mutators at: index
-		]
-	].
-	
-	"in case the coin is too high is because the lucky one is the last one"
-	lastIndex := probabilities size.
+	selectionCounter := selectionCounter + 1.
+	isPilotPhase := selectionCounter < pilotPhaseMax.
+	swarm := isPilotPhase
+		         ifTrue: [ "Pilot phase, we take the next swarm in round robin"
+			         swarms at: selectionCounter \\ numberOfSwarms + 1 ]
+		         ifFalse: [ "not in pilot phase anymore, use the best swarm"
+		         self bestSwarm ].
 
-	^ mutators last
+	lastMutatedSelector := swarm selectMutatorFrom: mutators.
+
+	selectionCounts
+		at: lastMutatedSelector
+		put: (selectionCounts at: lastMutatedSelector) + 1.
+
+	(isPilotPhase or: [selectionCounter \\ updatePeriod = 0]) ifTrue: [
+			swarm
+				updateProbabilitiesWithSuccesses: successCounts
+				onSelections: selectionCounts.
+			1 to: mutators size do: [ :i |
+					selectionCounts at: i put: 0.
+					successCounts at: i put: 0 ] ].
+
+	^ mutators at: lastMutatedSelector
 ]
 
 { #category : 'accessing' }
@@ -176,71 +212,4 @@ UmeMOPTMutatorSelector >> updatePeriod [
 UmeMOPTMutatorSelector >> updatePeriod: anInteger [
 
 	updatePeriod := anInteger
-]
-
-{ #category : 'updating' }
-UmeMOPTMutatorSelector >> updateProbabilities [
-
-	| totalLocalEfficiency localEfficiencies sum |
-
-	totalLocalEfficiency := 0.0.
-	localEfficiencies := Array new: probabilities size.
-
-	"recreate the the targetProbabilities based on their effectiveness"
-	1 to: probabilities size do: [ :i | | localSelections localSuccesses localEfficiency |
-		localSelections := selectionCounts at: i.
-		localSuccesses := successCounts at: i.
-		localEfficiency := localSelections > 0 ifTrue: [ localSuccesses / localSelections asFloat ] ifFalse: [ 0.0 ].
-		localEfficiency := localEfficiency + 0.001.
-		localEfficiencies at: i put: localEfficiency.
-		totalLocalEfficiency := totalLocalEfficiency + localEfficiency
-	].
-
-	"Normalize efficiencies"
-	localEfficiencies := localEfficiencies collect: [ :p | p / totalLocalEfficiency ].
-
-	"Update the local best efficiencies and positions
-	We are going to use it to update the new velocicies"
-	1 to: localEfficiencies do: [ :i |
-		(localEfficiencies at: i) > (localBestEfficiencies at: i)
-			ifTrue: [
-				localBestEfficiencies at: i put: (localEfficiencies at: i).
-				localBestProbabilities at: i put: (probabilities at: i).
-			]
-	].
-
-	sum := 0.0.
-	1 to: probabilities size do: [ :i | | localBestProbability velocity newProb |
-		"update the velocity of each one"
-		localBestProbability := localBestProbabilities at: i.
-		velocity := velocities at: i.
-		velocity := (omega * velocity) + (phi * random next * (localBestProbability - (probabilities at: i))).
-		velocities at: i put: velocity.
-		
-		"re compute the probability of each one"
-		newProb := (probabilities at: i) + velocity.
-		newProb := newProb min: maxProbability max: minProbability.
-		probabilities at: i put: newProb.
-		sum := sum + newProb
-	].
-
-	"Normalize the swarm probabilities, and make them uniform if they reached 0"
-	probabilities :=  ((sum > 0) ifTrue: [
-		probabilities collect: [ :p | p / sum ] ] ifFalse: [
-		probabilities collect: [ :_ | 1.0 / probabilities size ].
-	]).
-
-	"restart the success and selection counters"
-	(1 to: selectionCounts size) do: [ :i |
-		selectionCounts at: i put: 0.
-		successCounts at: i put: 0
-	].
-
-	selectionCounter := 0
-]
-
-{ #category : 'accessing' }
-UmeMOPTMutatorSelector >> velocities [
-
-	^ velocities
 ]

--- a/Ume/UmeMOPTMutatorSelector.class.st
+++ b/Ume/UmeMOPTMutatorSelector.class.st
@@ -13,7 +13,8 @@ Class {
 		'swarms',
 		'lastMutatedSelector',
 		'pilotPhaseMax',
-		'inertia'
+		'inertia',
+		'globalBestProbabilities'
 	],
 	#category : 'Ume-Selector Heuristics',
 	#package : 'Ume',
@@ -41,6 +42,18 @@ UmeMOPTMutatorSelector >> feed: feedback [
 ]
 
 { #category : 'accessing' }
+UmeMOPTMutatorSelector >> globalBestProbabilities [
+
+	^ globalBestProbabilities
+]
+
+{ #category : 'accessing' }
+UmeMOPTMutatorSelector >> globalBestProbabilities: anObject [
+
+	globalBestProbabilities := anObject
+]
+
+{ #category : 'accessing' }
 UmeMOPTMutatorSelector >> inertia [
 
 	^ inertia
@@ -62,7 +75,6 @@ UmeMOPTMutatorSelector >> initialize [
 	inertia := 0.72.
 	updatePeriod := 100.
 	selectionCounter := 0.
-	successCounts := {}.
 	random := Random new.
 	
 	"how many warm up executions should be done to get the swarms up and running"
@@ -72,26 +84,24 @@ UmeMOPTMutatorSelector >> initialize [
 { #category : 'initialization' }
 UmeMOPTMutatorSelector >> initializeSwarms: mutators [
 
-	| count uniform |
-
+	| count |
 	count := mutators size.
-	
+
 	swarms := (1 to: numberOfSwarms) collect: [ :i |
-		UmeMOPTSwarm new
-			mopt: self;
-			initializeSwarm: mutators;
-			yourself
-	].
-	
-	uniform := 1.0 / count asFloat.
-	
+			          UmeMOPTSwarm new
+				          mopt: self;
+				          initializeSwarm: mutators;
+				          yourself ].
+
+	globalBestProbabilities := Array new: count withAll: 0.5.
+
 	minProbability := 0.001.
 	maxProbability := 0.998.
-	
+
 	selectionCounts := Array new: count withAll: 0.
 	successCounts := Array new: count withAll: 0.
 	lastMutatedSelector := 1.
-	selectionCounter := 0.
+	selectionCounter := 0
 ]
 
 { #category : 'accessing' }
@@ -155,6 +165,7 @@ UmeMOPTMutatorSelector >> selectMutator: mutators [
 	selectionCounts at: lastMutatedSelector put: (selectionCounts at: lastMutatedSelector) + 1.
 
 	(selectionCounter \\ updatePeriod = 0) ifTrue: [
+		self updateGlobalBestProbabilitiesWithSuccesses: successCounts.
 		swarm updateProbabilitiesWithSuccesses: successCounts onSelections: selectionCounts ].
 
 	selectionCounter \\ updatePeriod = 0 ifTrue: [
@@ -181,6 +192,17 @@ UmeMOPTMutatorSelector >> selectionCounts [
 UmeMOPTMutatorSelector >> successCounts [
 
 	^ successCounts
+]
+
+{ #category : 'as yet unclassified' }
+UmeMOPTMutatorSelector >> updateGlobalBestProbabilitiesWithSuccesses: successes [
+
+	| totalSuccesses |
+	totalSuccesses := successes sum.
+	1 to: globalBestProbabilities size do: [ :i |
+			| particleSuccesses |
+			particleSuccesses := successes at: i.
+			globalBestProbabilities at: i put: particleSuccesses / totalSuccesses ]
 ]
 
 { #category : 'accessing' }

--- a/Ume/UmeMOPTMutatorSelector.class.st
+++ b/Ume/UmeMOPTMutatorSelector.class.st
@@ -2,8 +2,6 @@ Class {
 	#name : 'UmeMOPTMutatorSelector',
 	#superclass : 'UmeMutatorSelector',
 	#instVars : [
-		'selectionCounts',
-		'successCounts',
 		'updatePeriod',
 		'selectionCounter',
 		'random',
@@ -14,7 +12,10 @@ Class {
 		'lastMutatedSelector',
 		'pilotPhaseMax',
 		'inertia',
-		'globalBestProbabilities'
+		'globalBestProbabilities',
+		'iterationSuccessCounts',
+		'iterationSelectionCounts',
+		'globalSuccessCounts'
 	],
 	#category : 'Ume-Selector Heuristics',
 	#package : 'Ume',
@@ -36,9 +37,9 @@ UmeMOPTMutatorSelector >> bestSwarm [
 { #category : 'feedback' }
 UmeMOPTMutatorSelector >> feed: feedback [
 
-	(((feedback isNotNil) and: [ feedback isPositive ]) and: [ lastMutatedSelector isNotNil ]) ifTrue: [ 
-			successCounts at: lastMutatedSelector put: (successCounts at: lastMutatedSelector) + 1
-	]
+	((feedback isNotNil and: [ feedback isPositive ]) and: [ lastMutatedSelector isNotNil ]) ifTrue: [
+			iterationSuccessCounts at: lastMutatedSelector put: (iterationSuccessCounts at: lastMutatedSelector) + 1.
+			globalSuccessCounts at: lastMutatedSelector put: (globalSuccessCounts at: lastMutatedSelector) + 1 ]
 ]
 
 { #category : 'accessing' }
@@ -98,8 +99,9 @@ UmeMOPTMutatorSelector >> initializeSwarms: mutators [
 	minProbability := 0.001.
 	maxProbability := 0.998.
 
-	selectionCounts := Array new: count withAll: 0.
-	successCounts := Array new: count withAll: 0.
+	globalSuccessCounts := Array new: count withAll: 0.
+	iterationSelectionCounts := Array new: count withAll: 0.
+	iterationSuccessCounts := Array new: count withAll: 0.
 	lastMutatedSelector := 1.
 	selectionCounter := 0
 ]
@@ -162,16 +164,14 @@ UmeMOPTMutatorSelector >> selectMutator: mutators [
 
 	lastMutatedSelector := swarm selectMutatorFrom: mutators.
 
-	selectionCounts at: lastMutatedSelector put: (selectionCounts at: lastMutatedSelector) + 1.
-
-	(selectionCounter \\ updatePeriod = 0) ifTrue: [
-		self updateGlobalBestProbabilitiesWithSuccesses: successCounts.
-		swarm updateProbabilitiesWithSuccesses: successCounts onSelections: selectionCounts ].
+	iterationSelectionCounts at: lastMutatedSelector put: (iterationSelectionCounts at: lastMutatedSelector) + 1.
 
 	selectionCounter \\ updatePeriod = 0 ifTrue: [
+			self updateGlobalBestProbabilitiesWithSuccesses: globalSuccessCounts.
+			swarm updateProbabilitiesWithSuccesses: iterationSuccessCounts onSelections: iterationSelectionCounts.
 			1 to: mutators size do: [ :i |
-					selectionCounts at: i put: 0.
-					successCounts at: i put: 0 ] ].
+					iterationSelectionCounts at: i put: 0.
+					iterationSuccessCounts at: i put: 0 ] ].
 
 	^ mutators at: lastMutatedSelector
 ]
@@ -185,13 +185,13 @@ UmeMOPTMutatorSelector >> selectionCounter [
 { #category : 'accessing' }
 UmeMOPTMutatorSelector >> selectionCounts [
 
-	^ selectionCounts
+	^ iterationSelectionCounts
 ]
 
 { #category : 'accessing' }
 UmeMOPTMutatorSelector >> successCounts [
 
-	^ successCounts
+	^ iterationSuccessCounts
 ]
 
 { #category : 'as yet unclassified' }

--- a/Ume/UmeMOPTMutatorSelector.class.st
+++ b/Ume/UmeMOPTMutatorSelector.class.st
@@ -6,15 +6,14 @@ Class {
 		'successCounts',
 		'updatePeriod',
 		'selectionCounter',
-		'omega',
-		'phi',
 		'random',
 		'maxProbability',
 		'minProbability',
 		'numberOfSwarms',
 		'swarms',
 		'lastMutatedSelector',
-		'pilotPhaseMax'
+		'pilotPhaseMax',
+		'inertia'
 	],
 	#category : 'Ume-Selector Heuristics',
 	#package : 'Ume',
@@ -41,6 +40,18 @@ UmeMOPTMutatorSelector >> feed: feedback [
 	]
 ]
 
+{ #category : 'accessing' }
+UmeMOPTMutatorSelector >> inertia [
+
+	^ inertia
+]
+
+{ #category : 'accessing' }
+UmeMOPTMutatorSelector >> inertia: aFloat [
+
+	inertia := aFloat
+]
+
 { #category : 'initialization' }
 UmeMOPTMutatorSelector >> initialize [
 
@@ -48,8 +59,7 @@ UmeMOPTMutatorSelector >> initialize [
 	
 	numberOfSwarms := 10.
 	
-	omega := 0.72.
-	phi := 1.5.
+	inertia := 0.72.
 	updatePeriod := 100.
 	selectionCounter := 0.
 	successCounts := {}.
@@ -123,30 +133,6 @@ UmeMOPTMutatorSelector >> mutatorWeights [
 ]
 
 { #category : 'accessing' }
-UmeMOPTMutatorSelector >> omega [
-
-	^ omega
-]
-
-{ #category : 'accessing' }
-UmeMOPTMutatorSelector >> omega: aFloat [
-
-	omega := aFloat
-]
-
-{ #category : 'accessing' }
-UmeMOPTMutatorSelector >> phi [
-
-	^ phi
-]
-
-{ #category : 'accessing' }
-UmeMOPTMutatorSelector >> phi: aFloat [
-
-	phi := aFloat
-]
-
-{ #category : 'accessing' }
 UmeMOPTMutatorSelector >> random [
 
 	^ random
@@ -154,29 +140,24 @@ UmeMOPTMutatorSelector >> random [
 
 { #category : 'enumerating' }
 UmeMOPTMutatorSelector >> selectMutator: mutators [
-	"if the probabilities were not assigned, we initialize them uniformly"
 
 	| swarm isPilotPhase |
-	swarms isNil ifTrue: [ self initializeSwarms: mutators ].
+	swarms ifNil: [ self initializeSwarms: mutators ].
 
 	selectionCounter := selectionCounter + 1.
-	isPilotPhase := selectionCounter < pilotPhaseMax.
+	isPilotPhase := selectionCounter < (pilotPhaseMax * numberOfSwarms).
 	swarm := isPilotPhase
-		         ifTrue: [ "Pilot phase, we take the next swarm in round robin"
-			         swarms at: selectionCounter \\ numberOfSwarms + 1 ]
-		         ifFalse: [ "not in pilot phase anymore, use the best swarm"
-		         self bestSwarm ].
+		         ifTrue: [ "Pilot phase, we take the next swarm in round robin" swarms at: selectionCounter \\ numberOfSwarms + 1 ]
+		         ifFalse: [ "not in pilot phase anymore, use the best swarm" self bestSwarm ].
 
 	lastMutatedSelector := swarm selectMutatorFrom: mutators.
 
-	selectionCounts
-		at: lastMutatedSelector
-		put: (selectionCounts at: lastMutatedSelector) + 1.
+	selectionCounts at: lastMutatedSelector put: (selectionCounts at: lastMutatedSelector) + 1.
 
-	(isPilotPhase or: [selectionCounter \\ updatePeriod = 0]) ifTrue: [
-			swarm
-				updateProbabilitiesWithSuccesses: successCounts
-				onSelections: selectionCounts.
+	(selectionCounter \\ updatePeriod = 0) ifTrue: [
+		swarm updateProbabilitiesWithSuccesses: successCounts onSelections: selectionCounts ].
+
+	selectionCounter \\ updatePeriod = 0 ifTrue: [
 			1 to: mutators size do: [ :i |
 					selectionCounts at: i put: 0.
 					successCounts at: i put: 0 ] ].

--- a/Ume/UmeMOPTMutatorSelector.class.st
+++ b/Ume/UmeMOPTMutatorSelector.class.st
@@ -11,7 +11,11 @@ Class {
 		'selectionCounter',
 		'omega',
 		'phi',
-		'random'
+		'random',
+		'localBestEfficiencies',
+		'localBestProbabilities',
+		'maxProbability',
+		'minProbability'
 	],
 	#category : 'Ume-Selector Heuristics',
 	#package : 'Ume',
@@ -45,12 +49,18 @@ UmeMOPTMutatorSelector >> initializeProbabilities: mutators [
 
 	count := mutators size.
 	uniform := 1.0 / count asFloat.
+	
+	localBestEfficiencies := Array new: count withAll: 0.
+	localBestProbabilities := Array new: count withAll: 0.
+	minProbability := 0.001.
+	maxProbability := 0.998.
+	
 	probabilities := (1 to: count) collect: [ :i | uniform ].
 	selectionCounts := Array new: count withAll: 0.
 	successCounts := Array new: count withAll: 0.
 	velocities := Array new: count withAll: 0.0.
 	lastIndex := 1.
-	selectionCounter := 0
+	selectionCounter := 0.
 ]
 
 { #category : 'accessing' }
@@ -171,39 +181,50 @@ UmeMOPTMutatorSelector >> updatePeriod: anInteger [
 { #category : 'updating' }
 UmeMOPTMutatorSelector >> updateProbabilities [
 
-	| totalEffectiveness targetProbabilities sum |
+	| totalLocalEfficiency localEfficiencies sum |
 
-	totalEffectiveness := 0.0.
-	targetProbabilities := Array new: probabilities size.
+	totalLocalEfficiency := 0.0.
+	localEfficiencies := Array new: probabilities size.
 
 	"recreate the the targetProbabilities based on their effectiveness"
-	(1 to: probabilities size) do: [ :i | | sel success effectiveness |
-		sel := selectionCounts at: i.
-		success := successCounts at: i.
-		effectiveness := sel > 0 ifTrue: [ success / sel asFloat ] ifFalse: [ 0.0 ].
-		effectiveness := effectiveness + 0.001.
-		targetProbabilities at: i put: effectiveness.
-		totalEffectiveness := totalEffectiveness + effectiveness
+	1 to: probabilities size do: [ :i | | localSelections localSuccesses localEfficiency |
+		localSelections := selectionCounts at: i.
+		localSuccesses := successCounts at: i.
+		localEfficiency := localSelections > 0 ifTrue: [ localSuccesses / localSelections asFloat ] ifFalse: [ 0.0 ].
+		localEfficiency := localEfficiency + 0.001.
+		localEfficiencies at: i put: localEfficiency.
+		totalLocalEfficiency := totalLocalEfficiency + localEfficiency
 	].
 
-	targetProbabilities := targetProbabilities collect: [ :p | p / totalEffectiveness ].
+	"Normalize efficiencies"
+	localEfficiencies := localEfficiencies collect: [ :p | p / totalLocalEfficiency ].
+
+	"Update the local best efficiencies and positions
+	We are going to use it to update the new velocicies"
+	1 to: localEfficiencies do: [ :i |
+		(localEfficiencies at: i) > (localBestEfficiencies at: i)
+			ifTrue: [
+				localBestEfficiencies at: i put: (localEfficiencies at: i).
+				localBestProbabilities at: i put: (probabilities at: i).
+			]
+	].
 
 	sum := 0.0.
-	(1 to: probabilities size) do: [ :i | | target velocity newProb |
-		"upadte the velocity of each one"
-		target := targetProbabilities at: i.
+	1 to: probabilities size do: [ :i | | localBestProbability velocity newProb |
+		"update the velocity of each one"
+		localBestProbability := localBestProbabilities at: i.
 		velocity := velocities at: i.
-		velocity := (omega * velocity) + (phi * random next * (target - (probabilities at: i))).
+		velocity := (omega * velocity) + (phi * random next * (localBestProbability - (probabilities at: i))).
 		velocities at: i put: velocity.
 		
 		"re compute the probability of each one"
 		newProb := (probabilities at: i) + velocity.
-		newProb := newProb max: 0.0.
+		newProb := newProb min: maxProbability max: minProbability.
 		probabilities at: i put: newProb.
 		sum := sum + newProb
 	].
 
-	"reassign the probabolity to uniform them based on the current total sum"
+	"Normalize the swarm probabilities, and make them uniform if they reached 0"
 	probabilities :=  ((sum > 0) ifTrue: [
 		probabilities collect: [ :p | p / sum ] ] ifFalse: [
 		probabilities collect: [ :_ | 1.0 / probabilities size ].

--- a/Ume/UmeMOPTSwarm.class.st
+++ b/Ume/UmeMOPTSwarm.class.st
@@ -1,0 +1,153 @@
+Class {
+	#name : 'UmeMOPTSwarm',
+	#superclass : 'Object',
+	#instVars : [
+		'probabilities',
+		'velocities',
+		'localBestEfficiencies',
+		'localBestProbabilities',
+		'mopt',
+		'swarmSucccesses',
+		'swarmSelections'
+	],
+	#category : 'Ume-Selector Heuristics',
+	#package : 'Ume',
+	#tag : 'Selector Heuristics'
+}
+
+{ #category : 'accessing' }
+UmeMOPTSwarm >> efficiency [
+
+	| selections |
+	selections := swarmSelections sum.
+	selections = 0 ifTrue: [ ^ 0 ].
+	^ swarmSucccesses sum / selections
+]
+
+{ #category : 'initialization' }
+UmeMOPTSwarm >> initializeSwarm: mutators [
+
+	| count notNormalizedProbabilities probabilitySum |
+	count := mutators size.
+
+	swarmSucccesses := Array new: count withAll: 0.
+	swarmSelections := Array new: count withAll: 0.
+
+	localBestEfficiencies := Array new: count withAll: 0.
+	localBestProbabilities := Array new: count withAll: 0.5.
+
+	notNormalizedProbabilities := (1 to: count) collect: [ :i | mopt random next ].
+	probabilitySum := notNormalizedProbabilities sum.
+
+	probabilities := notNormalizedProbabilities collect: [ :e | e / probabilitySum ].
+	velocities := (1 to: count) collect: [ :i | 0.1 ].
+]
+
+{ #category : 'accessing' }
+UmeMOPTSwarm >> mopt [
+
+	^ mopt
+]
+
+{ #category : 'accessing' }
+UmeMOPTSwarm >> mopt: anObject [
+
+	mopt := anObject
+]
+
+{ #category : 'accessing' }
+UmeMOPTSwarm >> mutatorWeights [
+
+	^ probabilities"selectionCounts"
+]
+
+{ #category : 'accessing' }
+UmeMOPTSwarm >> probabilities [
+
+	^ probabilities
+]
+
+{ #category : 'as yet unclassified' }
+UmeMOPTSwarm >> selectMutatorFrom: mutatorList [
+	"get the total probability sum"
+
+	| total roll cumulative |
+	total := probabilities sum.
+	"throw a coin"
+	roll := total * mopt random next.
+	cumulative := 0.0.
+
+	"look for the lucky one"
+	probabilities withIndexDo: [ :prob :index |
+			cumulative := cumulative + prob.
+			roll <= cumulative ifTrue: [ ^ index ] ].
+
+	"in case the coin is too high is because the lucky one is the last one"
+	^ probabilities size
+]
+
+{ #category : 'updating' }
+UmeMOPTSwarm >> updateProbabilitiesWithSuccesses: localSuccesses onSelections: localSelections [
+
+	| totalLocalEfficiency localEfficiencies sum |
+	totalLocalEfficiency := 0.0.
+	localEfficiencies := Array new: probabilities size.
+
+	1 to: probabilities size do: [ :i |
+			| localSuccess localSelection localEfficiency |
+			
+			"Cumulate the total number of selections and successes of this swarm"
+			swarmSucccesses at: i put: (swarmSucccesses at: i) + (localSuccesses at: i).
+			swarmSelections at: i put: (swarmSelections at: i) + (localSelections at: i).		
+			
+			localSuccess := localSuccesses at: i.
+			localSelection := localSelections at: i.
+			localEfficiency := localSelection = 0
+				                   ifTrue: [ 0 ]
+				                   ifFalse: [ localSuccess / localSelection ].
+			localEfficiencies at: i put: localEfficiency + 0.001.
+			totalLocalEfficiency := totalLocalEfficiency
+			                        + (localEfficiency + 0.001) ].
+
+	"Normalize efficiencies"
+	localEfficiencies := localEfficiencies collect: [ :p |
+		                     p / totalLocalEfficiency ].
+
+	"Update the local best efficiencies and positions
+	We are going to use it to update the new velocicies"
+	localEfficiencies withIndexDo: [ :localEfficiency :i |
+			localEfficiency > (localBestEfficiencies at: i) ifTrue: [
+					localBestEfficiencies at: i put: localEfficiency.
+					localBestProbabilities at: i put: (probabilities at: i) ] ].
+
+	sum := 0.0.
+	1 to: probabilities size do: [ :i |
+			| localBestProbability velocity newProb |
+			"update the velocity of each one"
+			localBestProbability := localBestProbabilities at: i.
+			velocity := velocities at: i.
+			velocity := mopt omega * velocity + (mopt phi * mopt random next
+			             * (localBestProbability - (probabilities at: i))).
+			velocities at: i put: velocity.
+
+			"re compute the probability of each one"
+			newProb := (probabilities at: i) + velocity.
+			newProb := newProb
+				           min: mopt maxProbability
+				           max: mopt minProbability.
+			probabilities at: i put: newProb.
+			sum := sum + newProb ].
+
+	"Normalize the swarm probabilities, and make them uniform if they reached 0"
+	probabilities := sum > 0
+		                 ifTrue: [ probabilities collect: [ :p | p / sum ] ]
+		                 ifFalse: [
+		                 probabilities collect: [ :_ |
+			                 1.0 / probabilities size ] ]
+]
+
+{ #category : 'accessing' }
+UmeMOPTSwarm >> velocities [
+
+	^ velocities
+]

--- a/Ume/UmeMOPTSwarm.class.st
+++ b/Ume/UmeMOPTSwarm.class.st
@@ -121,11 +121,15 @@ UmeMOPTSwarm >> updateProbabilitiesWithSuccesses: localSuccesses onSelections: l
 
 	sum := 0.0.
 	1 to: probabilities size do: [ :i |
-			| localBestProbability velocity newProb |
+			| localBestProbability globalBestProbability velocity newProb randomValue currentProbability |
 			"update the velocity of each one"
 			localBestProbability := localBestProbabilities at: i.
+			globalBestProbability := mopt globalBestProbabilities at: i.
 			velocity := velocities at: i.
-			velocity := mopt inertia * velocity + (mopt random next * (localBestProbability - (probabilities at: i))).
+			randomValue := mopt random next.
+			currentProbability := (probabilities at: i).
+			velocity := mopt inertia * velocity + (randomValue * (localBestProbability - currentProbability))
+														+ (randomValue * (globalBestProbability - currentProbability)) .
 			velocities at: i put: velocity.
 
 			"re compute the probability of each one"

--- a/Ume/UmeMOPTSwarm.class.st
+++ b/Ume/UmeMOPTSwarm.class.st
@@ -69,9 +69,9 @@ UmeMOPTSwarm >> probabilities [
 
 { #category : 'as yet unclassified' }
 UmeMOPTSwarm >> selectMutatorFrom: mutatorList [
-	"get the total probability sum"
 
 	| total roll cumulative |
+	"get the total probability sum"
 	total := probabilities sum.
 	"throw a coin"
 	roll := total * mopt random next.
@@ -95,23 +95,22 @@ UmeMOPTSwarm >> updateProbabilitiesWithSuccesses: localSuccesses onSelections: l
 
 	1 to: probabilities size do: [ :i |
 			| localSuccess localSelection localEfficiency |
-			
-			"Cumulate the total number of selections and successes of this swarm"
-			swarmSucccesses at: i put: (swarmSucccesses at: i) + (localSuccesses at: i).
-			swarmSelections at: i put: (swarmSelections at: i) + (localSelections at: i).		
-			
 			localSuccess := localSuccesses at: i.
 			localSelection := localSelections at: i.
+
+			"Cumulate the total number of selections and successes of this swarm"
+			swarmSucccesses at: i put: (swarmSucccesses at: i) + localSuccess.
+			swarmSelections at: i put: (swarmSelections at: i) + localSelection.		
+			
 			localEfficiency := localSelection = 0
 				                   ifTrue: [ 0 ]
 				                   ifFalse: [ localSuccess / localSelection ].
-			localEfficiencies at: i put: localEfficiency + 0.001.
+			localEfficiencies at: i put: localEfficiency.
 			totalLocalEfficiency := totalLocalEfficiency
-			                        + (localEfficiency + 0.001) ].
+			                        + localEfficiency ].
 
-	"Normalize efficiencies"
-	localEfficiencies := localEfficiencies collect: [ :p |
-		                     p / totalLocalEfficiency ].
+	"Normalize efficiencies if totalLocalEfficiency is not 0"
+	totalLocalEfficiency = 0 ifFalse: [ localEfficiencies :=  localEfficiencies collect: [ :p | p / totalLocalEfficiency ] ].
 
 	"Update the local best efficiencies and positions
 	We are going to use it to update the new velocicies"
@@ -126,8 +125,7 @@ UmeMOPTSwarm >> updateProbabilitiesWithSuccesses: localSuccesses onSelections: l
 			"update the velocity of each one"
 			localBestProbability := localBestProbabilities at: i.
 			velocity := velocities at: i.
-			velocity := mopt omega * velocity + (mopt phi * mopt random next
-			             * (localBestProbability - (probabilities at: i))).
+			velocity := mopt inertia * velocity + (mopt random next * (localBestProbability - (probabilities at: i))).
 			velocities at: i put: velocity.
 
 			"re compute the probability of each one"


### PR DESCRIPTION
<img width="3104" height="3000" alt="image" src="https://github.com/user-attachments/assets/616134b4-6d9c-4ea9-badc-da2fbf4581cc" />
The goal of MOpt is to find the best probability distribution of a set of mutators to maximise the number of new interesting test cases that can be found with these operators during fuzzing. To find it, MOpt will iteratively perform fuzzing and update the distribution according to the results of the fuzzing.  

In MOpt, the mutators (or mutation operators) are associated with particles. A swarm of particles is a group of particles where each represents one of the mutators from the set. MOpt uses several swarms to find the optimal probability distribution.

Each particle has a position between 0 and 1, that corresponds to the probability of the associated mutator, and a velocity that indicates in which direction the particle moves (to 0 or to 1) and how fast. For each individual particle we compute its local efficiency, which is the number of new interesting test cases yielded by the mutator divided by the number of time the mutator was selected. Each particle keeps the position associated with its higher efficiency reached, called its local best.

MOpt also computes the global efficiency of the particles, which is the number of interesting test cases yielded by all particles across all swarms that represent the same operator. Then for each operator, we compute the ratio of this quantity over the total number of interesting test cases generated, and this gives us the global best position of each operator.

Finally the particles velocities are updated to make them move towards their local best and global best positions. For the next fuzzing iteration MOpt chooses the best swarm, which is the swarm that yielded the higher number of interesting test cases.