### PR TITLE
Plot improvement

### DIFF
--- a/Ume/UmeShrinkingBenchmarkReport.class.st
+++ b/Ume/UmeShrinkingBenchmarkReport.class.st
@@ -18,10 +18,13 @@ UmeShrinkingBenchmarkReport >> add: result for: shrinkerClass [
 { #category : 'as yet unclassified' }
 UmeShrinkingBenchmarkReport >> asPlots: section [ 
 
-	| plt p colors count |
+	| plt p colors count popup |
 	plt := RSChart new.
 	colors := { Color blue . Color red . Color green . Color orange . Color purple . Color cyan }.
 	
+	popup := RSPopupDecoration new.
+   plt addDecoration: popup.
+
 	count := results size.
 	colors := (1 to: count) collect: [ :i | 
         Color 
@@ -30,11 +33,16 @@ UmeShrinkingBenchmarkReport >> asPlots: section [
             v: 0.85
     ].
 	
-	results doWithIndex: [ :data :index |
-		p := RSLinePlot new x: ( 1 to: data size ) y: (self collectResult: data for: section).
+	results doWithIndex: [ :data :index | | shape y |
+		y := (self collectResult: data for: section).
+		p := RSLinePlot new x: ( 1 to: data size ) y: y.
 		p color: (colors at: index).
-		p marker: (RSEllipse new size: 4; color: (colors atWrap: index)).
-		plt add: p
+		shape := RSEllipse new size: 8; color: (colors atWrap: index).
+		p marker: shape.
+		plt add: p.
+		popup chartPopupBuilder 
+            for: p 
+            color: (colors at: index).
 	].
 
 	plt xlabel: 'test number';
@@ -50,7 +58,7 @@ UmeShrinkingBenchmarkReport >> asPlots: section [
 		maxChartValueY: 100  ]. 
 	
 	plt build.
-
+	
 	self buildLegend: plt with: section palette: colors. 
 
 	^ plt canvas 

--- a/Ume/UmeShrinkingBenchmarkReport.class.st
+++ b/Ume/UmeShrinkingBenchmarkReport.class.st
@@ -37,7 +37,7 @@ UmeShrinkingBenchmarkReport >> asPlots: section [
 		y := (self collectResult: data for: section).
 		p := RSLinePlot new x: ( 1 to: data size ) y: y.
 		p color: (colors at: index).
-		shape := RSEllipse new size: 8; color: (colors atWrap: index).
+		shape := RSEllipse new size: 4; color: (colors atWrap: index).
 		p marker: shape.
 		plt add: p.
 		popup chartPopupBuilder 

--- a/Ume/UmeShrinkingBenchmarkReport.class.st
+++ b/Ume/UmeShrinkingBenchmarkReport.class.st
@@ -53,7 +53,7 @@ UmeShrinkingBenchmarkReport >> asPlots: section [
 	plt horizontalTick numberOfTicks: ((results anyOne size) min: 10).
 	plt horizontalTick labelConversion: [ :val | val rounded ].
 	
-	( section = '%inputReduction' ) ifTrue: [ 
+	( section = '%inputReduction'  or: section = '%problemPreservation' ) ifTrue: [ 
 		plt minChartValueY: 0;
 		maxChartValueY: 100  ]. 
 	

--- a/Ume/UmeShrinkingBenchmarkReport.class.st
+++ b/Ume/UmeShrinkingBenchmarkReport.class.st
@@ -44,7 +44,11 @@ UmeShrinkingBenchmarkReport >> asPlots: section [
 	
 	plt horizontalTick numberOfTicks: ((results anyOne size) min: 10).
 	plt horizontalTick labelConversion: [ :val | val rounded ].
-
+	
+	( section = '%inputReduction' ) ifTrue: [ 
+		plt minChartValueY: 0;
+		maxChartValueY: 100  ]. 
+	
 	plt build.
 
 	self buildLegend: plt with: section palette: colors. 

--- a/Ume/UmeShrinkingRegexBenchmark.class.st
+++ b/Ume/UmeShrinkingRegexBenchmark.class.st
@@ -21,7 +21,7 @@ UmeShrinkingRegexBenchmark >> initialize [
 	            'b*(b|bc|bc?)b+' 'b*b(b|bc||bac?)b+' 'b*b(b|ba*||bac?)b+'
 	            'b*b(b|b.*||bac?)b+' 'b*b(b|b.*|ba?.*c+bba+|)b+'
 	            'b*b(b|b.*|b*|)b+' 'b*b(b|(bc.*|b*|))b+'
-					'b*(c|a*|||)(b|.+|b*b*)b+' 'b*(a((c?b.*))*.?|a*|||)(b|b?|b*b*)c+'
+					"'b*(c|a*|||)(b|.+|b*b*)b+' 'b*(a((c?b.*))*.?|a*|||)(b|b?|b*b*)c+'
 	            'b*(ac+a*.()c|.*|||)(b+|b?|b*b*)c+'
 	            'b*(ac+a*.a?b*|.*|||)(|b*.|c+a+.*)b+'
 	            'b*(acca+a*..()c|.*|||)(b+|b?|b*b*)c+'
@@ -49,6 +49,6 @@ UmeShrinkingRegexBenchmark >> initialize [
 	            'a.*(cc.a.a*..cbc|.*|.|)(b|.()(.+|.)*.*)c'
 	            'a.*(cc.a.a*..cbc|.|.|)(b|.*)(.+|.)*.*cc'
 	            'a.*(cc.a.a*c.cbc|.|.|)(c|.*)(.+|.)*a.*cc'
-	            'a.*(cc.a.a*c..cbc...|)(c|.*)(.+|.)*a.*cc'
+	            'a.*(cc.a.a*c..cbc...|)(c|.*)(.+|.)*a.*cc'"
 				) collect: [ :regex | ShrinkerTest input: regex oracle: oracle ]
 ]

--- a/Ume/UmeShrinkingRegexBenchmark.class.st
+++ b/Ume/UmeShrinkingRegexBenchmark.class.st
@@ -21,7 +21,7 @@ UmeShrinkingRegexBenchmark >> initialize [
 	            'b*(b|bc|bc?)b+' 'b*b(b|bc||bac?)b+' 'b*b(b|ba*||bac?)b+'
 	            'b*b(b|b.*||bac?)b+' 'b*b(b|b.*|ba?.*c+bba+|)b+'
 	            'b*b(b|b.*|b*|)b+' 'b*b(b|(bc.*|b*|))b+'
-					"'b*(c|a*|||)(b|.+|b*b*)b+' 'b*(a((c?b.*))*.?|a*|||)(b|b?|b*b*)c+'
+					'b*(c|a*|||)(b|.+|b*b*)b+' 'b*(a((c?b.*))*.?|a*|||)(b|b?|b*b*)c+'
 	            'b*(ac+a*.()c|.*|||)(b+|b?|b*b*)c+'
 	            'b*(ac+a*.a?b*|.*|||)(|b*.|c+a+.*)b+'
 	            'b*(acca+a*..()c|.*|||)(b+|b?|b*b*)c+'
@@ -49,6 +49,6 @@ UmeShrinkingRegexBenchmark >> initialize [
 	            'a.*(cc.a.a*..cbc|.*|.|)(b|.()(.+|.)*.*)c'
 	            'a.*(cc.a.a*..cbc|.|.|)(b|.*)(.+|.)*.*cc'
 	            'a.*(cc.a.a*c.cbc|.|.|)(c|.*)(.+|.)*a.*cc'
-	            'a.*(cc.a.a*c..cbc...|)(c|.*)(.+|.)*a.*cc'"
+	            'a.*(cc.a.a*c..cbc...|)(c|.*)(.+|.)*a.*cc'
 				) collect: [ :regex | ShrinkerTest input: regex oracle: oracle ]
 ]


### PR DESCRIPTION
# Printing plot improvement 
Here is some little improvement on the previously made benchmark plot. 
As a reminder, this plot visualisation is used to have a visual feedback fromt the benchmark report and have several method:
`plotFailedReductions`, `plotInputReduction`, `plotNeededReductions`, `PlotProblemPreservation` and `plotTotalTime`.

### Input reduction and problem preservation plots
To upgrade readability I made the y axe be from 0 to 100% in order to respect the data.
<img width="1571" height="856" alt="image" src="https://github.com/user-attachments/assets/c1f750f7-17af-4889-9e25-9958680e6fa2" />

### Values details
So we can compare algorithm correctly, I added a popup window showing the exact benchmark values. You can see it by moving the mouse from left to right. 

<img width="1541" height="843" alt="image" src="https://github.com/user-attachments/assets/1a899c97-8992-46d0-be42-fed3639605c9" />
